### PR TITLE
A new algorithm_globals to replace use of qiskit.utils instance

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,7 +67,7 @@ jobs:
           sudo apt-get -y install pandoc graphviz python3-enchant hunspell-en-us
           pip install pyenchant
           # append to reno config
-          echo "earliest_version: 0.1.0" >> releasenotes/config.yam
+          echo "earliest_version: 0.1.0" >> releasenotes/config.yaml
         shell: bash
       - run: pip check
         if: ${{ !cancelled() }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -184,6 +184,7 @@ jobs:
         run: |
           pip install jupyter qiskit-terra[visualization]
           sudo apt-get install -y pandoc graphviz
+          echo "earliest_version: 0.1.0" >> releasenotes/config.yaml
         shell: bash
       - name: Run Qiskit Algorithms Tutorials
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,6 +66,8 @@ jobs:
         run: |
           sudo apt-get -y install pandoc graphviz python3-enchant hunspell-en-us
           pip install pyenchant
+          # append to reno config
+          echo "earliest_version: 0.1.0" >> releasenotes/config.yam
         shell: bash
       - run: pip check
         if: ${{ !cancelled() }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -188,7 +188,6 @@ jobs:
           QISKIT_PARALLEL: False
           QISKIT_DOCS_BUILD_TUTORIALS: 'always'
         run: |
-          tools/ignore_untagged_notes.sh
           make html
           cd docs/_build/html
           mkdir artifacts

--- a/Makefile
+++ b/Makefile
@@ -79,4 +79,4 @@ coverage:
 coverage_erase:
 	coverage erase
 
-clean: coverage_erase;
+clean: clean_sphinx coverage_erase;

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -15,14 +15,22 @@ SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
 SOURCEDIR     = .
 BUILDDIR      = _build
+STUBSDIR      = stubs
 
 # Put it first so that "make" without argument is like "make help".
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
-.PHONY: help Makefile
+spell:
+	@$(SPHINXBUILD) -M spelling "$(SOURCEDIR)" "$(BUILDDIR)" -W -T --keep-going $(SPHINXOPTS) $(O)
+
+clean:
+	rm -rf $(BUILDDIR)
+	rm -rf $(STUBSDIR)
+
+.PHONY: help spell clean Makefile
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
-	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" -W -T --keep-going $(SPHINXOPTS) $(O)

--- a/docs/apidocs/qiskit_algorithms.utils.algorithm_globals.rst
+++ b/docs/apidocs/qiskit_algorithms.utils.algorithm_globals.rst
@@ -1,0 +1,6 @@
+﻿.. _qiskit_algorithms.utils.algorithm_globals:
+
+.. automodule:: qiskit_algorithms.utils.algorithm_globals
+   :no-members:
+   :no-inherited-members:
+   :no-special-members:

--- a/qiskit_algorithms/__init__.py
+++ b/qiskit_algorithms/__init__.py
@@ -203,12 +203,17 @@ Exceptions
 Utility classes
 ---------------
 
-Utility classes used by algorithms (mainly for type-hinting purposes).
+Utility classes and function used by algorithms.
 
 .. autosummary::
    :toctree: ../stubs/
 
    AlgorithmJob
+
+.. autosummary::
+   :toctree:
+
+   utils.algorithm_globals
 
 """
 from .algorithm_job import AlgorithmJob

--- a/qiskit_algorithms/amplitude_amplifiers/grover.py
+++ b/qiskit_algorithms/amplitude_amplifiers/grover.py
@@ -22,9 +22,9 @@ import numpy as np
 from qiskit import ClassicalRegister, QuantumCircuit
 from qiskit.primitives import BaseSampler
 from qiskit.quantum_info import Statevector
-from qiskit.utils import algorithm_globals
 
 from qiskit_algorithms.exceptions import AlgorithmError
+from qiskit_algorithms.utils import algorithm_globals
 
 from .amplification_problem import AmplificationProblem
 from .amplitude_amplifier import AmplitudeAmplifier, AmplitudeAmplifierResult

--- a/qiskit_algorithms/optimizers/adam_amsgrad.py
+++ b/qiskit_algorithms/optimizers/adam_amsgrad.py
@@ -43,13 +43,6 @@ class ADAM(Optimizer):
         [2]: Sashank J. Reddi and Satyen Kale and Sanjiv Kumar (2018),
              On the Convergence of Adam and Beyond.
              `arXiv:1904.09237 <https://arxiv.org/abs/1904.09237>`_
-
-    .. note::
-
-        This component has some function that is normally random. If you want to reproduce behavior
-        then you should set the random number generator seed in the algorithm_globals
-        (``qiskit.utils.algorithm_globals.random_seed = seed``).
-
     """
 
     _OPTIONS = [

--- a/qiskit_algorithms/optimizers/gsls.py
+++ b/qiskit_algorithms/optimizers/gsls.py
@@ -16,9 +16,10 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from typing import Any, SupportsFloat
+
 import numpy as np
 
-from qiskit.utils import algorithm_globals
+from qiskit_algorithms.utils import algorithm_globals
 from .optimizer import Optimizer, OptimizerSupportLevel, OptimizerResult, POINT
 
 
@@ -33,7 +34,7 @@ class GSLS(Optimizer):
 
         This component has some function that is normally random. If you want to reproduce behavior
         then you should set the random number generator seed in the algorithm_globals
-        (``qiskit.utils.algorithm_globals.random_seed = seed``).
+        (``qiskit_algorithms.utils.algorithm_globals.random_seed = seed``).
     """
 
     _OPTIONS = [

--- a/qiskit_algorithms/optimizers/p_bfgs.py
+++ b/qiskit_algorithms/optimizers/p_bfgs.py
@@ -21,9 +21,9 @@ from typing import SupportsFloat
 
 import numpy as np
 
-from qiskit.utils import algorithm_globals
 from qiskit.utils.validation import validate_min
 
+from qiskit_algorithms.utils import algorithm_globals
 from .optimizer import OptimizerResult, POINT
 from .scipy_optimizer import SciPyOptimizer
 
@@ -42,6 +42,12 @@ class P_BFGS(SciPyOptimizer):  # pylint: disable=invalid-name
     Uses scipy.optimize.fmin_l_bfgs_b.
     For further detail, please refer to
     https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.fmin_l_bfgs_b.html
+
+    .. note::
+
+    This component has some function that is normally random. If you want to reproduce behavior
+    then you should set the random number generator seed in the algorithm_globals
+    (``qiskit_algorithms.utils.algorithm_globals.random_seed = seed``).
     """
 
     _OPTIONS = ["maxfun", "ftol", "iprint"]

--- a/qiskit_algorithms/optimizers/p_bfgs.py
+++ b/qiskit_algorithms/optimizers/p_bfgs.py
@@ -45,9 +45,9 @@ class P_BFGS(SciPyOptimizer):  # pylint: disable=invalid-name
 
     .. note::
 
-    This component has some function that is normally random. If you want to reproduce behavior
-    then you should set the random number generator seed in the algorithm_globals
-    (``qiskit_algorithms.utils.algorithm_globals.random_seed = seed``).
+        This component has some function that is normally random. If you want to reproduce behavior
+        then you should set the random number generator seed in the algorithm_globals
+        (``qiskit_algorithms.utils.algorithm_globals.random_seed = seed``).
     """
 
     _OPTIONS = ["maxfun", "ftol", "iprint"]

--- a/qiskit_algorithms/optimizers/qnspsa.py
+++ b/qiskit_algorithms/optimizers/qnspsa.py
@@ -51,7 +51,7 @@ class QNSPSA(SPSA):
 
         This component has some function that is normally random. If you want to reproduce behavior
         then you should set the random number generator seed in the algorithm_globals
-        (``qiskit.utils.algorithm_globals.random_seed = seed``).
+        (``qiskit_algorithms.utils.algorithm_globals.random_seed = seed``).
 
     Examples:
 

--- a/qiskit_algorithms/optimizers/spsa.py
+++ b/qiskit_algorithms/optimizers/spsa.py
@@ -26,7 +26,7 @@ from time import time
 import scipy
 import numpy as np
 
-from qiskit.utils import algorithm_globals
+from qiskit_algorithms.utils import algorithm_globals
 
 from .optimizer import Optimizer, OptimizerSupportLevel, OptimizerResult, POINT
 
@@ -77,7 +77,7 @@ class SPSA(Optimizer):
 
         This component has some function that is normally random. If you want to reproduce behavior
         then you should set the random number generator seed in the algorithm_globals
-        (``qiskit.utils.algorithm_globals.random_seed = seed``).
+        (``qiskit_algorithms.utils.algorithm_globals.random_seed = seed``).
 
 
     Examples:

--- a/qiskit_algorithms/optimizers/umda.py
+++ b/qiskit_algorithms/optimizers/umda.py
@@ -16,10 +16,11 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from typing import Any
+
 import numpy as np
 from scipy.stats import norm
-from qiskit.utils import algorithm_globals
 
+from qiskit_algorithms.utils import algorithm_globals
 from .optimizer import OptimizerResult, POINT
 from .scipy_optimizer import Optimizer, OptimizerSupportLevel
 
@@ -72,7 +73,6 @@ class UMDA(Optimizer):
 
             from qiskit_algorithms.optimizers import UMDA
             from qiskit_algorithms import QAOA
-            from qiskit.utils import QuantumInstance
             from qiskit.quantum_info import Pauli
             from qiskit.primitives import Sampler
 
@@ -102,6 +102,11 @@ class UMDA(Optimizer):
             qaoa = QAOA(Sampler(), opt,reps=p)
             result = qaoa.compute_minimum_eigenvalue(operator=H2_op)
 
+    .. note::
+
+        This component has some function that is normally random. If you want to reproduce behavior
+        then you should set the random number generator seed in the algorithm_globals
+        (``qiskit_algorithms.utils.algorithm_globals.random_seed = seed``).
 
     References:
 

--- a/qiskit_algorithms/time_evolvers/pvqd/pvqd.py
+++ b/qiskit_algorithms/time_evolvers/pvqd/pvqd.py
@@ -23,7 +23,7 @@ from qiskit.circuit.library import PauliEvolutionGate
 from qiskit.primitives import BaseEstimator
 from qiskit.quantum_info.operators.base_operator import BaseOperator
 from qiskit.synthesis import EvolutionSynthesis, LieTrotter
-from qiskit.utils import algorithm_globals
+from qiskit_algorithms.utils import algorithm_globals
 
 from ...exceptions import AlgorithmError, QiskitError
 from ...optimizers import Minimizer, Optimizer

--- a/qiskit_algorithms/utils/__init__.py
+++ b/qiskit_algorithms/utils/__init__.py
@@ -12,10 +12,12 @@
 
 """Common qiskit_algorithms utility functions."""
 
+from .algorithm_globals import algorithm_globals
 from .validate_initial_point import validate_initial_point
 from .validate_bounds import validate_bounds
 
 __all__ = [
+    "algorithm_globals",
     "validate_initial_point",
     "validate_bounds",
 ]

--- a/qiskit_algorithms/utils/algorithm_globals.py
+++ b/qiskit_algorithms/utils/algorithm_globals.py
@@ -1,0 +1,98 @@
+# This code is part of a Qiskit project.
+#
+# (C) Copyright IBM 2019, 2023.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Algorithm Globals"""
+
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+
+
+class QiskitAlgorithmGlobals:
+    """Class for global properties."""
+
+    # The code is done to work even after some future removal of algorithm_globals
+    # from Qiskit (qiskit.utils). All that is needed in the future, after that, if
+    # this is updated, is just the logic in the except blocks.
+    #
+    # If the Qiskit version exists this acts a redirect to that (it delegates the
+    # calls off to it). In the future when that does not exist this has similar code
+    # in the except blocks here, as noted above, that will take over. By delegating
+    # to the Qiskit instance it means that any existing code that uses that continues
+    # to work. Logic here in qiskit_algorithms though uses this instance and the
+    # random check here has logic to warn if the seed here is not the same as the Qiskit
+    # version so we can detect direct usage of the Qiskit version and alert the user to
+    # change their code to use this. So simply changing from:
+    #     from qiskit.utils import algorithm_globals
+    # to
+    #     from qiskit_algorithm.utils import algorithm_globals
+
+    def __init__(self) -> None:
+        self._random_seed: int | None = None
+        self._random = None
+
+    @property
+    def random_seed(self) -> int | None:
+        """Return random seed."""
+        try:
+            from qiskit.utils import algorithm_globals as qiskit_globals
+
+            return qiskit_globals.random_seed
+
+        except ImportError:
+            return self._random_seed
+
+    @random_seed.setter
+    def random_seed(self, seed: int | None) -> None:
+        """Set random seed."""
+        try:
+            from qiskit.utils import algorithm_globals as qiskit_globals
+
+            qiskit_globals.random_seed = seed
+            # Mirror the seed here when set via this random_seed. If the seed is
+            # set on the qiskit.utils instance then we can detect it's different
+            self._random_seed = seed
+
+        except ImportError:
+            self._random_seed = seed
+            self._random = None
+
+    @property
+    def random(self) -> np.random.Generator:
+        """Return a numpy np.random.Generator (default_rng) using random_seed."""
+        try:
+            from qiskit.utils import algorithm_globals as qiskit_globals
+
+            if self._random_seed != qiskit_globals.random_seed:
+                # If the seeds are different - likely this local is None and the qiskit.utils
+                # algorithms global was seeded directly then we will warn to use this here as
+                # the Qiskit version is planned to be removed in a future version of Qiskit.
+                warnings.warn(
+                    "Using random that is seeded via qiskit.utils algorithm_globals is deprecated "
+                    "since version 0.2.0. Instead set random_seed directly to "
+                    "qiskit_algorithms.utils algorithm_globals.",
+                    category=DeprecationWarning,
+                    stacklevel=2,
+                )
+
+            return qiskit_globals.random
+
+        except ImportError:
+            if self._random is None:
+                self._random = np.random.default_rng(self._random_seed)
+            return self._random
+
+
+# Global instance to be used as the entry point for globals.
+algorithm_globals = QiskitAlgorithmGlobals()

--- a/qiskit_algorithms/utils/algorithm_globals.py
+++ b/qiskit_algorithms/utils/algorithm_globals.py
@@ -10,7 +10,27 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""Algorithm Globals"""
+"""
+utils.algorithm_globals
+=======================
+Common (global) properties used across qiskit_algorithms.
+
+.. currentmodule:: qiskit_algorithms.utils.algorithm_globals
+
+Includes:
+
+  * Random number generator and random seed.
+
+    Algorithms can use the generator for random values, as needed, and it
+    can be seeded here for reproducible results when using such an algorithm.
+    This is often important, for example in unit tests, where the same
+    outcome is desired each time (reproducible) and not have it be variable
+    due to randomness.
+
+Attributes:
+    random_seed (int | None): Random generator seed (read/write).
+    random (np.random.Generator): Random generator (read-only)
+"""
 
 from __future__ import annotations
 
@@ -20,7 +40,7 @@ import numpy as np
 
 
 class QiskitAlgorithmGlobals:
-    """Class for global properties."""
+    """Global properties for algorithms."""
 
     # The code is done to work even after some future removal of algorithm_globals
     # from Qiskit (qiskit.utils). All that is needed in the future, after that, if
@@ -44,7 +64,7 @@ class QiskitAlgorithmGlobals:
 
     @property
     def random_seed(self) -> int | None:
-        """Return random seed."""
+        """Random seed property (getter/setter)."""
         try:
             from qiskit.utils import algorithm_globals as qiskit_globals
 
@@ -55,7 +75,11 @@ class QiskitAlgorithmGlobals:
 
     @random_seed.setter
     def random_seed(self, seed: int | None) -> None:
-        """Set random seed."""
+        """Set the random generator seed.
+
+        Args:
+            seed: If ``None`` then internally a random value is used as a seed
+        """
         try:
             from qiskit.utils import algorithm_globals as qiskit_globals
 

--- a/qiskit_algorithms/utils/validate_initial_point.py
+++ b/qiskit_algorithms/utils/validate_initial_point.py
@@ -19,7 +19,7 @@ from collections.abc import Sequence
 import numpy as np
 
 from qiskit.circuit import QuantumCircuit
-from qiskit.utils import algorithm_globals
+from qiskit_algorithms.utils import algorithm_globals
 
 
 def validate_initial_point(

--- a/qiskit_algorithms/variational_algorithm.py
+++ b/qiskit_algorithms/variational_algorithm.py
@@ -23,7 +23,7 @@ overridden to opt-out of this infrastructure but still meet the interface requir
 
     This component has some function that is normally random. If you want to reproduce behavior
     then you should set the random number generator seed in the algorithm_globals
-    (``qiskit.utils.algorithm_globals.random_seed = seed``).
+    (``qiskit_algorithms.utils.algorithm_globals.random_seed = seed``).
 """
 
 from __future__ import annotations

--- a/releasenotes/notes/algorithm_globals-9a8afe956f974c86.yaml
+++ b/releasenotes/notes/algorithm_globals-9a8afe956f974c86.yaml
@@ -1,0 +1,39 @@
+---
+upgrade:
+  - |
+    The ``qiskit-algorithms`` code uses a common random number generator,
+    which can be seeded for reproducibility. The algorithms code here, having
+    originated in Qiskit and having been moved here, used random function from
+    ``qiskit.utils`` which was seeded as follows::
+
+        from qiskit.utils import algorithm_globals
+        algorithm_globals.random_seed = 101
+
+    Now this will continue to work in ``qiskit-algorithms``, until such time
+    as the ``algorithm_globals`` are removed from ``Qiskit``, however you are
+    highly recommended to already change to import/seed the ``algorithm_globals``
+    that is now supplied by ``qiskit-algorithms`` thus::
+
+        from qiskit_algorithms.utils import algorithm_globals
+        algorithm_globals.random_seed = 101
+
+    As can be seen it's simply a change to the import statement, so as to import
+    the ``qiskit_algorithms`` instance rather than the one from ``qiskit``.
+
+    This has been done to afford a transition and not break end-users code by supporting
+    seeding the random generator as it was done before. How does it work - well,
+    while the ``qiskit.utils`` version exists, the ``qiskit-algorithms`` version
+    simply delegates its function to that instance. However the main codebase of
+    ``qiskit-algorithms`` has already been altered to use the new instance and
+    the delegation function, that accesses the random generator, will warn with
+    a message to switch to seeding the ``qiskit-algorithms`` version if it detects
+    a difference in the seed, A difference could exist if the ``random_seed``
+    was set direct to the ``qiskit.utils`` instance.
+
+    At such a time when the ``qiskit.utils`` ``algorithm_globals`` version no
+    longer exists, rather than delegating the functionality to that, it will use
+    identical logic which it already has, so no further user change will be
+    required if you already transitioned to seeding the ``qiskit_algorithms.utils``
+    ``algorithms_globals``.
+
+

--- a/releasenotes/notes/algorithm_globals-9a8afe956f974c86.yaml
+++ b/releasenotes/notes/algorithm_globals-9a8afe956f974c86.yaml
@@ -27,7 +27,7 @@ upgrade:
     ``qiskit-algorithms`` has already been altered to use the new instance and
     the delegation function, that accesses the random generator, will warn with
     a message to switch to seeding the ``qiskit-algorithms`` version if it detects
-    a difference in the seed, A difference could exist if the ``random_seed``
+    a difference in the seed. A difference could exist if the ``random_seed``
     was set direct to the ``qiskit.utils`` instance.
 
     At such a time when the ``qiskit.utils`` ``algorithm_globals`` version no

--- a/test/algorithms_test_case.py
+++ b/test/algorithms_test_case.py
@@ -21,6 +21,8 @@ import os
 import unittest
 import time
 
+from qiskit_algorithms.utils import algorithm_globals
+
 # disable deprecation warnings that can cause log output overflow
 # pylint: disable=unused-argument
 
@@ -45,6 +47,7 @@ class QiskitAlgorithmsTestCase(unittest.TestCase, ABC):
         self._class_location = __file__
 
     def tearDown(self) -> None:
+        algorithm_globals.random_seed = None
         elapsed = time.time() - self._started_at
         if elapsed > 5.0:
             print(f"({round(elapsed, 2):.2f}s)", flush=True)

--- a/test/eigensolvers/test_vqd.py
+++ b/test/eigensolvers/test_vqd.py
@@ -23,12 +23,12 @@ from qiskit.circuit.library import TwoLocal, RealAmplitudes
 from qiskit.primitives import Sampler, Estimator
 from qiskit.quantum_info import SparsePauliOp
 from qiskit.quantum_info.operators import Operator
-from qiskit.utils import algorithm_globals
 
 from qiskit_algorithms.eigensolvers import VQD, VQDResult
 from qiskit_algorithms import AlgorithmError
 from qiskit_algorithms.optimizers import COBYLA, L_BFGS_B, SLSQP, SPSA
 from qiskit_algorithms.state_fidelities import ComputeUncompute
+from qiskit_algorithms.utils import algorithm_globals
 
 H2_SPARSE_PAULI = SparsePauliOp.from_list(
     [

--- a/test/minimum_eigensolvers/test_adapt_vqe.py
+++ b/test/minimum_eigensolvers/test_adapt_vqe.py
@@ -23,11 +23,11 @@ from qiskit.circuit import QuantumCircuit, QuantumRegister
 from qiskit.circuit.library import EvolvedOperatorAnsatz
 from qiskit.primitives import Estimator
 from qiskit.quantum_info import SparsePauliOp
-from qiskit.utils import algorithm_globals
 
 from qiskit_algorithms.minimum_eigensolvers import VQE
 from qiskit_algorithms.minimum_eigensolvers.adapt_vqe import AdaptVQE, TerminationCriterion
 from qiskit_algorithms.optimizers import SLSQP
+from qiskit_algorithms.utils import algorithm_globals
 
 
 @ddt

--- a/test/minimum_eigensolvers/test_qaoa.py
+++ b/test/minimum_eigensolvers/test_qaoa.py
@@ -26,10 +26,10 @@ from qiskit.circuit import Parameter
 from qiskit.primitives import Sampler
 from qiskit.quantum_info import Pauli, SparsePauliOp
 from qiskit.result import QuasiDistribution
-from qiskit.utils import algorithm_globals
 
 from qiskit_algorithms.minimum_eigensolvers import QAOA
 from qiskit_algorithms.optimizers import COBYLA, NELDER_MEAD
+from qiskit_algorithms.utils import algorithm_globals
 
 W1 = np.array([[0, 1, 0, 1], [1, 0, 1, 0], [0, 1, 0, 1], [1, 0, 1, 0]])
 P1 = 1

--- a/test/minimum_eigensolvers/test_sampling_vqe.py
+++ b/test/minimum_eigensolvers/test_sampling_vqe.py
@@ -25,12 +25,13 @@ from qiskit.circuit import ParameterVector, QuantumCircuit
 from qiskit.circuit.library import RealAmplitudes, TwoLocal
 from qiskit.primitives import Sampler
 from qiskit.quantum_info import Operator, Pauli, SparsePauliOp
-from qiskit.utils import algorithm_globals
 
 from qiskit_algorithms import AlgorithmError
 from qiskit_algorithms.minimum_eigensolvers import SamplingVQE
 from qiskit_algorithms.optimizers import L_BFGS_B, QNSPSA, SLSQP, OptimizerResult
 from qiskit_algorithms.state_fidelities import ComputeUncompute
+from qiskit_algorithms.utils import algorithm_globals
+
 
 # pylint: disable=invalid-name
 def _mock_optimizer(fun, x0, jac=None, bounds=None, inputs=None):

--- a/test/minimum_eigensolvers/test_vqe.py
+++ b/test/minimum_eigensolvers/test_vqe.py
@@ -24,7 +24,6 @@ from qiskit import QuantumCircuit
 from qiskit.circuit.library import RealAmplitudes, TwoLocal
 from qiskit.quantum_info import SparsePauliOp, Operator, Pauli
 from qiskit.primitives import Estimator, Sampler
-from qiskit.utils import algorithm_globals
 
 from qiskit_algorithms import AlgorithmError
 from qiskit_algorithms.gradients import ParamShiftEstimatorGradient
@@ -42,6 +41,8 @@ from qiskit_algorithms.optimizers import (
     TNC,
 )
 from qiskit_algorithms.state_fidelities import ComputeUncompute
+from qiskit_algorithms.utils import algorithm_globals
+
 
 # pylint: disable=invalid-name
 def _mock_optimizer(fun, x0, jac=None, bounds=None, inputs=None) -> OptimizerResult:

--- a/test/optimizers/test_optimizer_aqgd.py
+++ b/test/optimizers/test_optimizer_aqgd.py
@@ -15,7 +15,6 @@
 import unittest
 from test import QiskitAlgorithmsTestCase
 from qiskit.circuit.library import RealAmplitudes
-from qiskit.utils import algorithm_globals
 from qiskit.primitives import Estimator
 from qiskit.quantum_info import SparsePauliOp
 from qiskit.test import slow_test
@@ -24,6 +23,7 @@ from qiskit_algorithms import AlgorithmError
 from qiskit_algorithms.gradients import LinCombEstimatorGradient
 from qiskit_algorithms.optimizers import AQGD
 from qiskit_algorithms.minimum_eigensolvers import VQE
+from qiskit_algorithms.utils import algorithm_globals
 
 
 class TestOptimizerAQGD(QiskitAlgorithmsTestCase):

--- a/test/optimizers/test_optimizers.py
+++ b/test/optimizers/test_optimizers.py
@@ -22,7 +22,7 @@ from scipy.optimize import rosen, rosen_der
 
 from qiskit.circuit.library import RealAmplitudes
 from qiskit.exceptions import MissingOptionalLibraryError
-from qiskit.utils import algorithm_globals, optionals
+from qiskit.utils import optionals
 from qiskit.primitives import Sampler
 
 from qiskit_algorithms.optimizers import (
@@ -48,6 +48,7 @@ from qiskit_algorithms.optimizers import (
     TNC,
     SciPyOptimizer,
 )
+from qiskit_algorithms.utils import algorithm_globals
 
 
 @ddt

--- a/test/optimizers/test_optimizers_scikitquant.py
+++ b/test/optimizers/test_optimizers_scikitquant.py
@@ -19,13 +19,13 @@ from ddt import ddt, data, unpack
 
 import numpy
 from qiskit.circuit.library import RealAmplitudes
-from qiskit.utils import algorithm_globals
 from qiskit.exceptions import MissingOptionalLibraryError
 from qiskit.primitives import Estimator
 from qiskit.quantum_info import SparsePauliOp
 
 from qiskit_algorithms.minimum_eigensolvers import VQE
 from qiskit_algorithms.optimizers import BOBYQA, SNOBFIT, IMFIL
+from qiskit_algorithms.utils import algorithm_globals
 
 
 @ddt

--- a/test/optimizers/test_spsa.py
+++ b/test/optimizers/test_spsa.py
@@ -20,9 +20,9 @@ import numpy as np
 from qiskit.circuit.library import PauliTwoDesign
 from qiskit.primitives import Estimator, Sampler
 from qiskit.quantum_info import SparsePauliOp, Statevector
-from qiskit.utils import algorithm_globals
 
 from qiskit_algorithms.optimizers import SPSA, QNSPSA
+from qiskit_algorithms.utils import algorithm_globals
 
 
 @ddt

--- a/test/optimizers/test_umda.py
+++ b/test/optimizers/test_umda.py
@@ -17,9 +17,8 @@ from test import QiskitAlgorithmsTestCase
 import numpy as np
 from scipy.optimize import rosen
 
-from qiskit.utils import algorithm_globals
-
 from qiskit_algorithms.optimizers.umda import UMDA
+from qiskit_algorithms.utils import algorithm_globals
 
 
 class TestUMDA(QiskitAlgorithmsTestCase):

--- a/test/time_evolvers/test_pvqd.py
+++ b/test/time_evolvers/test_pvqd.py
@@ -23,13 +23,13 @@ from qiskit.circuit import Gate, Parameter, QuantumCircuit
 from qiskit.circuit.library import EfficientSU2
 from qiskit.primitives import Estimator, Sampler
 from qiskit.quantum_info import Pauli, SparsePauliOp
-from qiskit.test import QiskitTestCase
-from qiskit.utils import algorithm_globals
 
 from qiskit_algorithms.time_evolvers import TimeEvolutionProblem
 from qiskit_algorithms.optimizers import L_BFGS_B, SPSA, GradientDescent, OptimizerResult
 from qiskit_algorithms.state_fidelities import ComputeUncompute
 from qiskit_algorithms.time_evolvers.pvqd import PVQD
+from qiskit_algorithms.utils import algorithm_globals
+
 
 # pylint: disable=unused-argument, invalid-name
 def gradient_supplied(fun, x0, jac, info):
@@ -270,7 +270,7 @@ class TestPVQD(QiskitAlgorithmsTestCase):
             _ = pvqd.evolve(problem)
 
 
-class TestPVQDUtils(QiskitTestCase):
+class TestPVQDUtils(QiskitAlgorithmsTestCase):
     """Test some utility functions for PVQD."""
 
     def setUp(self):

--- a/test/time_evolvers/test_trotter_qrte.py
+++ b/test/time_evolvers/test_trotter_qrte.py
@@ -22,12 +22,12 @@ from numpy.testing import assert_raises
 from qiskit import QuantumCircuit
 from qiskit.circuit.library import ZGate
 from qiskit.quantum_info import Statevector, Pauli, SparsePauliOp
-from qiskit.utils import algorithm_globals
 from qiskit.circuit import Parameter
 from qiskit.primitives import Estimator
 from qiskit.synthesis import SuzukiTrotter, QDrift
 
 from qiskit_algorithms.time_evolvers import TimeEvolutionProblem, TrotterQRTE
+from qiskit_algorithms.utils import algorithm_globals
 
 
 @ddt

--- a/test/time_evolvers/variational/test_var_qite.py
+++ b/test/time_evolvers/variational/test_var_qite.py
@@ -21,7 +21,6 @@ from qiskit import QuantumCircuit
 from qiskit.circuit import Parameter
 from qiskit.primitives import Estimator
 from qiskit.quantum_info import SparsePauliOp, Pauli
-from qiskit.utils import algorithm_globals
 from qiskit.circuit.library import EfficientSU2
 from qiskit.quantum_info import Statevector
 
@@ -30,6 +29,7 @@ from qiskit_algorithms import TimeEvolutionProblem, VarQITE
 from qiskit_algorithms.time_evolvers.variational import (
     ImaginaryMcLachlanPrinciple,
 )
+from qiskit_algorithms.utils import algorithm_globals
 
 
 @ddt

--- a/test/time_evolvers/variational/test_var_qrte.py
+++ b/test/time_evolvers/variational/test_var_qrte.py
@@ -22,7 +22,6 @@ from qiskit import QuantumCircuit
 from qiskit.circuit import Parameter, ParameterVector
 from qiskit.circuit.library import EfficientSU2
 from qiskit.primitives import Estimator
-from qiskit.utils import algorithm_globals
 from qiskit.quantum_info import SparsePauliOp, Pauli, Statevector
 
 from qiskit_algorithms.gradients import LinCombQGT, DerivativeType, LinCombEstimatorGradient
@@ -30,6 +29,7 @@ from qiskit_algorithms import TimeEvolutionProblem, VarQRTE
 from qiskit_algorithms.time_evolvers.variational import (
     RealMcLachlanPrinciple,
 )
+from qiskit_algorithms.utils import algorithm_globals
 
 
 @ddt

--- a/test/utils/test_validate_bounds.py
+++ b/test/utils/test_validate_bounds.py
@@ -18,9 +18,7 @@ from unittest.mock import Mock
 
 import numpy as np
 
-from qiskit.utils import algorithm_globals
-
-from qiskit_algorithms.utils import validate_bounds
+from qiskit_algorithms.utils import algorithm_globals, validate_bounds
 
 
 class TestValidateBounds(QiskitAlgorithmsTestCase):

--- a/test/utils/test_validate_initial_point.py
+++ b/test/utils/test_validate_initial_point.py
@@ -18,9 +18,7 @@ from unittest.mock import Mock
 
 import numpy as np
 
-from qiskit.utils import algorithm_globals
-
-from qiskit_algorithms.utils import validate_initial_point
+from qiskit_algorithms.utils import algorithm_globals, validate_initial_point
 
 
 class TestValidateInitialPoint(QiskitAlgorithmsTestCase):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes #21

Adds a new algorithm_globals here in qiskit_algorithms as part of the migration out of Qiskit. At present the instance here works with the instance in Qiskit, delegates to it, so that user code which may set the seed there still works as expected on the algorithms here. The code here has the same logic as the one in qiskit and that will be used when the Qiskit instance is removed by which time users should be using/seeding this instance directly.

The algorithm_globals introduced here only supports `random` and `random_seed`. 

The `massive` property of the qiskit.utils version was only used in opflow so is not needed in this algorithm_globals.

The qiskit.utils algorithm_globals also has a `num_processes` but this seems only being used by Qiskit Nature - it allows how many processes to be used by Qiskit's parallel map, something I think is more directly configurable now which back in Aqua times, when the globals came about I think it always used all local CPU cores. Anyway since this is all related to the Qiskit parallel_map usage, having some setting here, that is not even used by the algorithms seems out of place.

### Details and comments

- [x] Add local algorithm globals
- [x] Update algorithm code to use this instance
- [x] Update test cases to seed this instance (not the qiskit.utils one)
- [x] Add release note

This first commit just completes the first two items above. While locally I have the test cases updated too I am leaving them for now seeding the qiskit.utils instance to show that the algorithms still use this (indirectly) as many tests will fail without the RNG being seeded for a reproducible outcome. This works locally I am just assuring it does when run through CI here. 

Ok CI passes e.g https://github.com/qiskit-community/qiskit-algorithms/actions/runs/5732026311/job/15534167826?pr=33 but it emits deprecation warnings about seeding the qiskit.utils instance e.g.
```
 /home/runner/work/qiskit-algorithms/qiskit-algorithms/qiskit_algorithms/utils/validate_initial_point.py:61: DeprecationWarning: Using random that is seeded via qiskit.utils algorithm_globals is deprecated since version 0.2.0. Instead set random_seed directly to qiskit_algorithms.utils algorithm_globals.
 ```
 
 So updating to add altered tests that seed the instance here. CI now passes just the same but no longer are deprecation warnings like above being emitted.
 
 Release note add. I updated the make files too as `make clean html` was not working and I expected it to - only manually deleting build and stubs would give me a clean run ahead of this change. 
