### PR TITLE
Replace raising QiskitError by AlgorithmError

### DIFF
--- a/qiskit_algorithms/minimum_eigensolvers/adapt_vqe.py
+++ b/qiskit_algorithms/minimum_eigensolvers/adapt_vqe.py
@@ -27,7 +27,7 @@ from qiskit.circuit.library import EvolvedOperatorAnsatz
 from qiskit.utils.deprecation import deprecate_arg, deprecate_func
 from qiskit.utils.validation import validate_min
 
-from qiskit_algorithms import AlgorithmError
+from qiskit_algorithms.exceptions import AlgorithmError
 from qiskit_algorithms.list_or_dict import ListOrDict
 
 from .minimum_eigensolver import MinimumEigensolver

--- a/qiskit_algorithms/minimum_eigensolvers/adapt_vqe.py
+++ b/qiskit_algorithms/minimum_eigensolvers/adapt_vqe.py
@@ -22,12 +22,12 @@ from typing import Any
 
 import numpy as np
 
-from qiskit import QiskitError
 from qiskit.quantum_info.operators.base_operator import BaseOperator
 from qiskit.circuit.library import EvolvedOperatorAnsatz
 from qiskit.utils.deprecation import deprecate_arg, deprecate_func
 from qiskit.utils.validation import validate_min
 
+from qiskit_algorithms import AlgorithmError
 from qiskit_algorithms.list_or_dict import ListOrDict
 
 from .minimum_eigensolver import MinimumEigensolver
@@ -239,8 +239,8 @@ class AdaptVQE(VariationalAlgorithm, MinimumEigensolver):
 
         Raises:
             TypeError: If an ansatz other than :class:`~.EvolvedOperatorAnsatz` is provided.
-            QiskitError: If all evaluated gradients lie below the convergence threshold in the first
-                iteration of the algorithm.
+            AlgorithmError: If all evaluated gradients lie below the convergence threshold in
+                the first iteration of the algorithm.
 
         Returns:
             An :class:`~.AdaptVQEResult` which is a :class:`~.VQEResult` but also but also
@@ -281,7 +281,7 @@ class AdaptVQE(VariationalAlgorithm, MinimumEigensolver):
             # log gradients
             if np.abs(max_grad[0]) < self.gradient_threshold:
                 if iteration == 1:
-                    raise QiskitError(
+                    raise AlgorithmError(
                         "All gradients have been evaluated to lie below the convergence threshold "
                         "during the first iteration of the algorithm. Try to either tighten the "
                         "convergence threshold or pick a different ansatz."

--- a/qiskit_algorithms/optimizers/snobfit.py
+++ b/qiskit_algorithms/optimizers/snobfit.py
@@ -17,7 +17,7 @@ from collections.abc import Callable
 from typing import Any
 
 import numpy as np
-from qiskit.exceptions import QiskitError
+from qiskit_algorithms.exceptions import AlgorithmError
 from qiskit_algorithms.utils import optionals as _optionals
 from .optimizer import Optimizer, OptimizerSupportLevel, OptimizerResult, POINT
 
@@ -53,13 +53,13 @@ class SNOBFIT(Optimizer):
 
         Raises:
             MissingOptionalLibraryError: scikit-quant or SQSnobFit not installed
-            QiskitError: If NumPy 1.24.0 or above is installed.
+            AlgorithmError: If NumPy 1.24.0 or above is installed.
                 See https://github.com/scikit-quant/scikit-quant/issues/24 for more details.
         """
         # check version
         version = tuple(map(int, np.__version__.split(".")))
         if version >= (1, 24, 0):
-            raise QiskitError(
+            raise AlgorithmError(
                 "SnobFit is incompatible with NumPy 1.24.0 or above, please "
                 "install a previous version. See also scikit-quant/scikit-quant#24."
             )

--- a/qiskit_algorithms/time_evolvers/pvqd/pvqd.py
+++ b/qiskit_algorithms/time_evolvers/pvqd/pvqd.py
@@ -25,7 +25,7 @@ from qiskit.quantum_info.operators.base_operator import BaseOperator
 from qiskit.synthesis import EvolutionSynthesis, LieTrotter
 from qiskit.utils import algorithm_globals
 
-from ...exceptions import AlgorithmError, QiskitError
+from ...exceptions import AlgorithmError
 from ...optimizers import Minimizer, Optimizer
 from ...state_fidelities.base_state_fidelity import BaseStateFidelity
 from ..real_time_evolver import RealTimeEvolver
@@ -420,12 +420,12 @@ class PVQD(RealTimeEvolver):
             )
 
         if self.ansatz.num_parameters == 0:
-            raise QiskitError(
+            raise AlgorithmError(
                 "The ansatz cannot have 0 parameters, otherwise it cannot be trained."
             )
 
         if len(self.initial_parameters) != self.ansatz.num_parameters:
-            raise QiskitError(
+            raise AlgorithmError(
                 f"Mismatching number of parameters in the ansatz ({self.ansatz.num_parameters}) "
                 f"and the initial parameters ({len(self.initial_parameters)})."
             )

--- a/releasenotes/notes/change_exception-85f9f8d86ac16720.yaml
+++ b/releasenotes/notes/change_exception-85f9f8d86ac16720.yaml
@@ -1,0 +1,12 @@
+---
+upgrade:
+  - |
+    A couple of algorithms here, :class:`.PVQD`, :class:`.AdaptVQE` and optimizer
+    :class:`.SNOBFIT`, directly raised a :class:`~qiskit.exceptions.QiskitError`.
+    These have been changed to raise an :class:`.AlgorithmError` instead. Algorithms
+    have now been moved out of ``Qiskit`` and this better distinguishes the exception to the
+    algorithms when raised. Now ``AlgorithmError`` was already raised elsewhere by the algorithms
+    here so this makes things more consistent too. Note, that as ``AlgorithmError``
+    internally extends ``QiskitError``, any code that might have caught that specifically
+    will continue to work. However we do recommend you update your code accordingly for
+    ``AlgorithmError``.

--- a/test/time_evolvers/test_pvqd.py
+++ b/test/time_evolvers/test_pvqd.py
@@ -18,7 +18,6 @@ from functools import partial
 import numpy as np
 from ddt import data, ddt, unpack
 
-from qiskit import QiskitError
 from qiskit.circuit import Gate, Parameter, QuantumCircuit
 from qiskit.circuit.library import EfficientSU2
 from qiskit.primitives import Estimator, Sampler
@@ -26,6 +25,7 @@ from qiskit.quantum_info import Pauli, SparsePauliOp
 from qiskit.test import QiskitTestCase
 from qiskit.utils import algorithm_globals
 
+from qiskit_algorithms import AlgorithmError
 from qiskit_algorithms.time_evolvers import TimeEvolutionProblem
 from qiskit_algorithms.optimizers import L_BFGS_B, SPSA, GradientDescent, OptimizerResult
 from qiskit_algorithms.state_fidelities import ComputeUncompute
@@ -222,7 +222,7 @@ class TestPVQD(QiskitAlgorithmsTestCase):
             optimizer=SPSA(maxiter=10, learning_rate=0.1, perturbation=0.01),
         )
 
-        with self.assertRaises(QiskitError):
+        with self.assertRaises(AlgorithmError):
             _ = pvqd.evolve(problem)
 
     def test_initial_state_raises(self):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
 
 In a couple of places `QiskitError` was directly raised. Normally the algorithms raise an `AlgorithmError` so given algorithms has been moved out of Qiskit, to better distinguish the exception to algorithms, and to make it consistent with elsewhere I changed the couple of places to raise AlgorithmError instead.
 
 Resolves #30 

### Details and comments

As AlgorithmError extends QiskitError its unlikely that this has any impact on anyone. I added a release note in case. Indeed the `test_pvqd` unit test, that checked an error condition continued to work unchanged - though I did change it to AlgorithmError as that is really what should be expected now.

Of course I ran tests, and built html locally and it was all good.... such a small change.... I did not run lint!
```
tools/check_copyright.py:1:0: R0401: Cyclic import (qiskit_algorithms -> qiskit_algorithms.minimum_eigensolvers -> qiskit_algorithms.minimum_eigensolvers.adapt_vqe) (cyclic-import)
```
