### PR TITLE
Remove `threshold` argument from AdaptVQE

### DIFF
--- a/qiskit_algorithms/minimum_eigensolvers/adapt_vqe.py
+++ b/qiskit_algorithms/minimum_eigensolvers/adapt_vqe.py
@@ -24,7 +24,6 @@ import numpy as np
 
 from qiskit.quantum_info.operators.base_operator import BaseOperator
 from qiskit.circuit.library import EvolvedOperatorAnsatz
-from qiskit.utils.deprecation import deprecate_arg, deprecate_func
 
 from qiskit_algorithms.utils.validation import validate_min
 from qiskit_algorithms.exceptions import AlgorithmError
@@ -98,12 +97,6 @@ class AdaptVQE(VariationalAlgorithm, MinimumEigensolver):
             algorithm is not bound in its number of iterations.
     """
 
-    @deprecate_arg(
-        "threshold",
-        since="0.24.0",
-        pending=True,
-        new_alias="gradient_threshold",
-    )
     def __init__(
         self,
         solver: VQE,
@@ -111,7 +104,6 @@ class AdaptVQE(VariationalAlgorithm, MinimumEigensolver):
         gradient_threshold: float = 1e-5,
         eigenvalue_threshold: float = 1e-5,
         max_iterations: int | None = None,
-        threshold: float | None = None,  # pylint: disable=unused-argument
     ) -> None:
         """
         Args:
@@ -119,7 +111,7 @@ class AdaptVQE(VariationalAlgorithm, MinimumEigensolver):
                 It is a requirement that the :attr:`~.VQE.ansatz` of this solver is of type
                 :class:`~qiskit.circuit.library.EvolvedOperatorAnsatz`.
             gradient_threshold: once all gradients have an absolute value smaller than this
-                threshold, the algorithm has converged and terminates.
+                threshold, the algorithm has converged and terminates. Defaults to ``1e-5``.
             eigenvalue_threshold: once the eigenvalue has changed by less than this threshold from
                 one iteration to the next, the algorithm has converged and terminates. When this
                 case occurs, the excitation included in the final iteration did not result in a
@@ -127,8 +119,6 @@ class AdaptVQE(VariationalAlgorithm, MinimumEigensolver):
                 are not considered.
             max_iterations: the maximum number of iterations for the adaptive loop. If ``None``, the
                 algorithm is not bound in its number of iterations.
-            threshold: once all gradients have an absolute value smaller than this threshold, the
-                algorithm has converged and terminates. Defaults to ``1e-5``.
         """
         validate_min("gradient_threshold", gradient_threshold, 1e-15)
         validate_min("eigenvalue_threshold", eigenvalue_threshold, 1e-15)
@@ -140,31 +130,6 @@ class AdaptVQE(VariationalAlgorithm, MinimumEigensolver):
         self._tmp_ansatz: EvolvedOperatorAnsatz | None = None
         self._excitation_pool: list[BaseOperator] = []
         self._excitation_list: list[BaseOperator] = []
-
-    @property
-    @deprecate_func(
-        since="0.24.0",
-        pending=True,
-        is_property=True,
-        additional_msg="Instead, use the gradient_threshold attribute.",
-    )
-    def threshold(self) -> float:
-        """The threshold for the gradients.
-
-        Once all gradients have an absolute value smaller than this threshold, the algorithm has
-        converged and terminates.
-        """
-        return self.gradient_threshold
-
-    @threshold.setter
-    @deprecate_func(
-        since="0.24.0",
-        pending=True,
-        is_property=True,
-        additional_msg="Instead, use the gradient_threshold attribute.",
-    )
-    def threshold(self, threshold: float) -> None:
-        self.gradient_threshold = threshold
 
     @property
     def initial_point(self) -> Sequence[float] | None:

--- a/releasenotes/notes/remove-deprecated-threshold-adaptvqe-7f862fe4b9b677d0.yaml
+++ b/releasenotes/notes/remove-deprecated-threshold-adaptvqe-7f862fe4b9b677d0.yaml
@@ -1,0 +1,15 @@
+---
+upgrade:
+  - |
+    The deprecated ``threshold`` input argument of :class:`~.AdaptVQE` has been removed,
+    and replaced by ``gradient_threshold``. This change was made to avoid confusion with
+    the later introduced ``eigenvalue_threshold`` argument. The updated AdaptVQE use
+    would look like this::
+
+        from qiskit_algorithms import VQE, AdaptVQE
+
+        adapt_vqe = AdaptVQE(
+                      VQE(Estimator(), ansatz, optimizer),
+                      gradient_threshold=1e-3,
+                      eigenvalue_threshold=1e-3
+                    )

--- a/test/minimum_eigensolvers/test_adapt_vqe.py
+++ b/test/minimum_eigensolvers/test_adapt_vqe.py
@@ -151,17 +151,6 @@ class TestAdaptVQE(QiskitAlgorithmsTestCase):
 
         self.assertEqual(res.termination_criterion, TerminationCriterion.CONVERGED)
 
-    def test_threshold_attribute(self):
-        """Test the (pending deprecated) threshold attribute"""
-        with self.assertWarns(PendingDeprecationWarning):
-            calc = AdaptVQE(
-                VQE(Estimator(), self.ansatz, self.optimizer),
-                threshold=1e-3,
-            )
-            res = calc.compute_minimum_eigenvalue(operator=self.h2_op)
-
-            self.assertEqual(res.termination_criterion, TerminationCriterion.CONVERGED)
-
     @data(
         ([1, 1], True),
         ([1, 11], False),


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fixes #37.


### Details and comments
I think that the removal of this argument is justified with the move to a new repository, the deprecation warning refers to `qiskit-terra` versions and can be confusing (particularly after the repo rename). And even though the previously emitted warning was "pending deprecation", I think that most users don't really tell apart a deprecation from a pending deprecation, and the alternative path has been laid out for long enough for users to be able to easily transition to the new argument.

