### PR TITLE
Remove best measurement text - fixes #48

### DIFF
--- a/qiskit_algorithms/minimum_eigensolvers/qaoa.py
+++ b/qiskit_algorithms/minimum_eigensolvers/qaoa.py
@@ -56,7 +56,7 @@ class QAOA(SamplingVQE):
     Attributes:
         sampler (BaseSampler): The sampler primitive to sample the circuits.
         optimizer (Optimizer | Minimizer): A classical optimizer to find the minimum energy. This
-            can either be a Qiskit :class:`.Optimizer` or a callable implementing the
+            can either be an :class:`.Optimizer` or a callable implementing the
             :class:`.Minimizer` protocol.
         reps (int): The integer parameter :math:`p`. Has a minimum valid value of 1.
         initial_state: An optional initial state to prepend the QAOA circuit with.
@@ -69,8 +69,8 @@ class QAOA(SamplingVQE):
             value.
         callback (Callable[[int, np.ndarray, float, dict[str, Any]], None] | None): A callback
             that can access the intermediate data at each optimization step. These data are: the
-            evaluation count, the optimizer parameters for the ansatz, the evaluated value, the
-            the metadata dictionary, and the best measurement.
+            evaluation count, the optimizer parameters for the ansatz, the evaluated value, and
+            the metadata dictionary.
 
     References:
         [1]: Farhi, E., Goldstone, J., Gutmann, S., "A Quantum Approximate Optimization Algorithm"
@@ -98,8 +98,8 @@ class QAOA(SamplingVQE):
         r"""
         Args:
             sampler: The sampler primitive to sample the circuits.
-            optimizer: A classical optimizer to find the minimum energy. This can either be a
-                Qiskit :class:`.Optimizer` or a callable implementing the :class:`.Minimizer`
+            optimizer: A classical optimizer to find the minimum energy. This can either be
+                an :class:`.Optimizer` or a callable implementing the :class:`.Minimizer`
                 protocol.
             reps: The integer parameter :math:`p`. Has a minimum valid value of 1.
             initial_state: An optional initial state to prepend the QAOA circuit with.

--- a/qiskit_algorithms/minimum_eigensolvers/sampling_vqe.py
+++ b/qiskit_algorithms/minimum_eigensolvers/sampling_vqe.py
@@ -95,7 +95,7 @@ class SamplingVQE(VariationalAlgorithm, SamplingMinimumEigensolver):
         sampler (BaseSampler): The sampler primitive to sample the circuits.
         ansatz (QuantumCircuit): A parameterized quantum circuit to prepare the trial state.
         optimizer (Optimizer | Minimizer): A classical optimizer to find the minimum energy. This
-            can either be a Qiskit :class:`.Optimizer` or a callable implementing the
+            can either be an :class:`.Optimizer` or a callable implementing the
             :class:`.Minimizer` protocol.
         aggregation (float | Callable[[list[tuple[float, complex]], float] | None):
             A float or callable to specify how the objective function evaluated on the basis states
@@ -128,7 +128,7 @@ class SamplingVQE(VariationalAlgorithm, SamplingMinimumEigensolver):
         Args:
             sampler: The sampler primitive to sample the circuits.
             ansatz: A parameterized quantum circuit to prepare the trial state.
-            optimizer: A classical optimizer to find the minimum energy. This can either be a Qiskit
+            optimizer: A classical optimizer to find the minimum energy. This can either be an
                 :class:`.Optimizer` or a callable implementing the :class:`.Minimizer` protocol.
             initial_point: An optional initial point (i.e. initial parameter values) for the
                 optimizer. The length of the initial point must match the number of :attr:`ansatz`


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes #48 

Removes the text that claimed in one place for the callback it included best measurement.

Also tweaked text in a couple of places so it says `an Optimizer` rather than `a Qiskit Optimizer`


### Details and comments


