### PR TITLE
Fix result print for SamplingVQE & QAOA - fixes #58

### DIFF
--- a/qiskit_algorithms/minimum_eigensolvers/sampling_mes.py
+++ b/qiskit_algorithms/minimum_eigensolvers/sampling_mes.py
@@ -123,15 +123,3 @@ class SamplingMinimumEigensolverResult(AlgorithmResult):
     def best_measurement(self, value: Mapping[str, Any]) -> None:
         """Set the best measurement over the entire optimization."""
         self._best_measurement = value
-
-    def __str__(self) -> str:
-        """Return a string representation of the result."""
-        disp = (
-            "SamplingMinimumEigensolverResult:\n"
-            + f"\tEigenvalue: {self.eigenvalue}\n"
-            + f"\tBest measurement\n: {self.best_measurement}\n"
-        )
-        if self.aux_operators_evaluated is not None:
-            disp += f"\n\tAuxiliary operator values: {self.aux_operators_evaluated}\n"
-
-        return disp

--- a/releasenotes/notes/update_sampling_result-6f65d2c54d7a88c3.yaml
+++ b/releasenotes/notes/update_sampling_result-6f65d2c54d7a88c3.yaml
@@ -1,0 +1,9 @@
+---
+other:
+  - |
+    Removed the custom ``__str__`` method from :class:`.SamplingMinimumEigensolverResult`
+    so that string conversion is based on the method of its parent :class:`.AlgorithmResult`
+    which prints all the result fields in a dictionary like format. The overidden method
+    had only printed a select couple of fields, unlike when normally printing a result all fields
+    are shown, and the lack of fields expected to be shown caused confusion when printing
+    results derived from that, such as returned by :class:`.SamplingVQE` and :class:`.QAOA`.

--- a/releasenotes/notes/update_sampling_result-6f65d2c54d7a88c3.yaml
+++ b/releasenotes/notes/update_sampling_result-6f65d2c54d7a88c3.yaml
@@ -3,7 +3,7 @@ other:
   - |
     Removed the custom ``__str__`` method from :class:`.SamplingMinimumEigensolverResult`
     so that string conversion is based on the method of its parent :class:`.AlgorithmResult`
-    which prints all the result fields in a dictionary like format. The overidden method
+    which prints all the result fields in a dictionary like format. The overridden method
     had only printed a select couple of fields, unlike when normally printing a result all fields
     are shown, and the lack of fields expected to be shown caused confusion when printing
     results derived from that, such as returned by :class:`.SamplingVQE` and :class:`.QAOA`.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes #58.

Simply removes the overriden `__str__` method in the sampling result class so conversion to string is done by the parent AlgorithmResult (as it done for all other results so it makes things consistent too).

Longer terms the change proposed in #53 will change things up by using dataclass so the result string format is wanted to be improved, maybe include a capability for just including the common fields or whatever things can be revisited at that point.


### Details and comments

Was 
```
>>> res = SamplingVQEResult()
>>> print(res)
SamplingMinimumEigensolverResult:
        Eigenvalue: None
        Best measurement
: None
```

Now
```
>>> res = SamplingVQEResult()
>>> print(res)
{   'aux_operators_evaluated': None,
    'best_measurement': None,
    'cost_function_evals': None,
    'eigenstate': None,
    'eigenvalue': None,
    'optimal_circuit': None,
    'optimal_parameters': None,
    'optimal_point': None,
    'optimal_value': None,
    'optimizer_evals': None,
    'optimizer_result': None,
    'optimizer_time': None}
```

