### PR TITLE
Short import for TrotterQRTE

### DIFF
--- a/docs/apidocs/qiskit_algorithms.time_evolvers.trotterization.rst
+++ b/docs/apidocs/qiskit_algorithms.time_evolvers.trotterization.rst
@@ -1,6 +1,0 @@
-﻿.. _qiskit_algorithms-time_evolvers-trotterization:
-
-.. automodule:: qiskit_algorithms.time_evolvers.trotterization
-   :no-members:
-   :no-inherited-members:
-   :no-special-members:

--- a/qiskit_algorithms/__init__.py
+++ b/qiskit_algorithms/__init__.py
@@ -30,8 +30,8 @@ gradients (:mod:`.gradients`) and fidelities of quantum states (:mod:`.state_fid
 These elements are frequently used in a variety of applications, such as variational optimization,
 time evolution and quantum machine learning.
 
-The quantum algorithms here all use 
-`Primitives <https://qiskit.org/documentation/apidoc/primitives.html>`__ 
+The quantum algorithms here all use
+`Primitives <https://qiskit.org/documentation/apidoc/primitives.html>`__
 to execute quantum circuits. This can be an
 ``Estimator``, which computes expectation values, or a ``Sampler`` which computes
 probability distributions. Refer to the specific algorithm for more information in this regard.
@@ -44,7 +44,7 @@ Algorithms
 The algorithms now presented are grouped by logical function, such
 as minimum eigensolvers, amplitude amplifiers, time evolvers etc. Within each group, the
 algorithms conform to an interface that allows them to be used interchangeably
-by different applications. E.g. a Qiskit Nature application may take a minimum 
+by different applications. E.g. a Qiskit Nature application may take a minimum
 eigensolver to solve a ground state problem, and require it to
 conform to the :class:`.MinimumEigensolver` interface. Any algorithm that conforms to
 the interface, for example :class:`.VQE`, can be used by this application.
@@ -200,6 +200,7 @@ used to train Quantum Boltzmann Machine Neural Networks for example.
    PVQDResult
    SciPyImaginaryEvolver
    SciPyRealEvolver
+   TrotterQRTE
    VarQITE
    VarQRTE
 
@@ -212,17 +213,6 @@ Classes used by variational quantum time evolution algorithms -
    :toctree:
 
    time_evolvers.variational
-
-
-Trotterization-based Quantum Real Time Evolution
-++++++++++++++++++++++++++++++++++++++++++++++++
-Trotterization-based quantum time evolution algorithms -
-:class:`~.time_evolvers.trotterization.TrotterQRTE`.
-
-.. autosummary::
-   :toctree:
-
-   time_evolvers.trotterization
 
 
 Miscellaneous
@@ -296,6 +286,7 @@ from .time_evolvers import (
     PVQDResult,
     SciPyImaginaryEvolver,
     SciPyRealEvolver,
+    TrotterQRTE,
     VarQITE,
     VarQRTE,
     VarQTE,
@@ -363,6 +354,7 @@ __all__ = [
     "PVQDResult",
     "SciPyRealEvolver",
     "SciPyImaginaryEvolver",
+    "TrotterQRTE",
     "IterativePhaseEstimation",
     "AlgorithmError",
     "estimate_observables",

--- a/qiskit_algorithms/time_evolvers/trotterization/__init__.py
+++ b/qiskit_algorithms/time_evolvers/trotterization/__init__.py
@@ -9,25 +9,8 @@
 # Any modifications or derivative works of this code must retain this
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
-"""
-Time Evolvers, Trotterization (:mod:`qiskit_algorithms.time_evolvers.variational`)
-==================================================================================
+""" The Time Evolvers, Trotterization package"""
 
-This package contains Trotterization-based Quantum Real Time Evolution algorithm.
-It is compliant with the new Quantum Time Evolution Framework and makes use of
-:class:`qiskit.synthesis.evolution.ProductFormula` and
-:class:`~qiskit.circuit.library.PauliEvolutionGate` implementations.
-
-Trotterization-based Quantum Real Time Evolution
-------------------------------------------------
-
-.. autosummary::
-   :toctree: ../stubs/
-   :nosignatures:
-
-    TrotterQRTE
-"""
-
-from qiskit_algorithms.time_evolvers.trotterization.trotter_qrte import TrotterQRTE
+from .trotter_qrte import TrotterQRTE
 
 __all__ = ["TrotterQRTE"]

--- a/qiskit_algorithms/time_evolvers/trotterization/trotter_qrte.py
+++ b/qiskit_algorithms/time_evolvers/trotterization/trotter_qrte.py
@@ -31,8 +31,8 @@ from qiskit_algorithms.observables_evaluator import estimate_observables
 class TrotterQRTE(RealTimeEvolver):
     """Quantum Real Time Evolution using Trotterization.
 
-    The type of Trotterization is defined by the ``ProductFormula`` provided to
-    the algorithm.
+    The type of Trotterization is defined by the :class:`~qiskit.synthesis.ProductFormula`
+    provided to the algorithm.
 
     Examples:
 

--- a/qiskit_algorithms/time_evolvers/trotterization/trotter_qrte.py
+++ b/qiskit_algorithms/time_evolvers/trotterization/trotter_qrte.py
@@ -30,7 +30,9 @@ from qiskit_algorithms.observables_evaluator import estimate_observables
 
 class TrotterQRTE(RealTimeEvolver):
     """Quantum Real Time Evolution using Trotterization.
-    Type of Trotterization is defined by a ``ProductFormula`` provided.
+
+    The type of Trotterization is defined by the ``ProductFormula`` provided to
+    the algorithm.
 
     Examples:
 
@@ -38,8 +40,7 @@ class TrotterQRTE(RealTimeEvolver):
 
             from qiskit.quantum_info import Pauli, SparsePauliOp
             from qiskit import QuantumCircuit
-            from qiskit_algorithms import TimeEvolutionProblem
-            from qiskit_algorithms.time_evolvers import TrotterQRTE
+            from qiskit_algorithms import TrotterQRTE, TimeEvolutionProblem
             from qiskit.primitives import Estimator
 
             operator = SparsePauliOp([Pauli("X"), Pauli("Z")])

--- a/qiskit_algorithms/time_evolvers/trotterization/trotter_qrte.py
+++ b/qiskit_algorithms/time_evolvers/trotterization/trotter_qrte.py
@@ -61,11 +61,12 @@ class TrotterQRTE(RealTimeEvolver):
     ) -> None:
         """
         Args:
-            product_formula: A Lie-Trotter-Suzuki product formula. If ``None`` provided, the
-                Lie-Trotter first order product formula with a single repetition is used. ``reps``
-                should be 1 to obtain a number of time-steps equal to ``num_timesteps`` and an
-                evaluation of :attr:`.TimeEvolutionProblem.aux_operators` at every time-step. If ``reps``
-                is larger than 1, the true number of time-steps will be ``num_timesteps * reps``.
+            product_formula: A Lie-Trotter-Suzuki product formula. If ``None`` provided (default),
+                the :class:`~qiskit.synthesis.LieTrotter` first order product formula with a single
+                repetition is used. ``reps`` should be 1 to obtain a number of time-steps equal to
+                ``num_timesteps`` and an evaluation of :attr:`.TimeEvolutionProblem.aux_operators`
+                at every time-step. If ``reps`` is larger than 1, the true number of time-steps will
+                be ``num_timesteps * reps``.
             num_timesteps: The number of time-steps the full evolution time is divided into
                 (repetitions of ``product_formula``)
             estimator: An estimator primitive used for calculating expectation values of
@@ -86,7 +87,7 @@ class TrotterQRTE(RealTimeEvolver):
         """Sets a product formula. If ``None`` provided, sets the Lie-Trotter first order product
         formula with a single repetition."""
         if product_formula is None:
-            product_formula = LieTrotter()
+            product_formula = LieTrotter(reps=1)
         self._product_formula = product_formula
 
     @property

--- a/test/time_evolvers/test_trotter_qrte.py
+++ b/test/time_evolvers/test_trotter_qrte.py
@@ -26,7 +26,7 @@ from qiskit.circuit import Parameter
 from qiskit.primitives import Estimator
 from qiskit.synthesis import SuzukiTrotter, QDrift
 
-from qiskit_algorithms.time_evolvers import TimeEvolutionProblem, TrotterQRTE
+from qiskit_algorithms import TimeEvolutionProblem, TrotterQRTE
 from qiskit_algorithms.utils import algorithm_globals
 
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
 
 While we allowed the new VQE etc to be imported from qiskit_algorithms the new TrotterQRTE was overlooked. It can now be imported from qiskit_algorithms so you do not need to import it from the sub-module, but that still works for any code that does. 
 
 Updated the docs so TrotterQRTE is documented  at that level along with the other algorithms. Also made a couple of highlighted and plain text items class refs to the content so they become links.
 
 Also the docstring stated the default was LieTrotter with reps=1 but was relying on the default value in LieTrotter being 1 to make this so. I set it explicitly just in case the default in the constructor ever gets changed.
### Details and comments


