### PR TITLE
[stable] Remove `py.typed`

### DIFF
--- a/.pylintdict
+++ b/.pylintdict
@@ -34,6 +34,7 @@ bool
 boyer
 brassard
 broyden
+bugfix
 callables
 cambridge
 cancelled
@@ -358,6 +359,7 @@ unitaries
 univariate
 uno
 unscaled
+untyped
 utils
 varadarajan
 variational

--- a/qiskit_algorithms/py.typed
+++ b/qiskit_algorithms/py.typed
@@ -1,1 +1,0 @@
-# Marker file for PEP 561.

--- a/releasenotes/notes/remove-typing-marker-2b1684ceb542b51a.yaml
+++ b/releasenotes/notes/remove-typing-marker-2b1684ceb542b51a.yaml
@@ -2,7 +2,7 @@
 fixes:
   - |
     Even though ``qiskit-algorithms`` included a ``py.typed`` marker, reporting
-    itself as being typed, the types were not checked and contained many errors.
-    This will be fixed in the 0.3 release but we are releasing a bugfix release
-    in an untyped form to allow dependent packages that are themselves typed to
+    itself as being typed, the types were not checked and contained errors.
+    We are releasing a bugfix release
+    in an untyped form to allow dependent packages, that are themselves typed, to
     continue type checking normally.

--- a/releasenotes/notes/remove-typing-marker-2b1684ceb542b51a.yaml
+++ b/releasenotes/notes/remove-typing-marker-2b1684ceb542b51a.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Even though ``qiskit-algorithms`` included a ``py.typed`` marker, reporting
+    itself as being typed, the types were not checked and contained many errors.
+    This will be fixed in the 0.3 release but we are releasing a bugfix release
+    in an untyped form to allow dependent packages that are themselves typed to
+    continue type checking normally.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Even though `qiskit-algorithms` included a `py.typed` marker, reporting
itself as being typed, the types were not checked and contained many errors.
This will be fixed in the 0.3 release (see #73) but I suggest that we release a
bugfix release in an untyped form to allow dependent packages that are
themselves typed to continue type checking normally.


### Details and comments


