### PR TITLE
Remove numpy 1.25 constraint

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,5 +1,2 @@
-# Numpy 1.25 deprecated some behaviours that we used, and caused the isometry
-# tests to flake. See https://github.com/Qiskit/qiskit-terra/issues/10305,
-# remove pin when resolving that.
-numpy<1.25
+# Constraints may be listed here
 

--- a/qiskit_algorithms/optimizers/snobfit.py
+++ b/qiskit_algorithms/optimizers/snobfit.py
@@ -57,8 +57,7 @@ class SNOBFIT(Optimizer):
                 See https://github.com/scikit-quant/scikit-quant/issues/24 for more details.
         """
         # check version
-        version = tuple(map(int, np.__version__.split(".")))
-        if version >= (1, 24, 0):
+        if tuple(map(int, np.__version__.split(".")[:2])) >= (1, 24):
             raise AlgorithmError(
                 "SnobFit is incompatible with NumPy 1.24.0 or above, please "
                 "install a previous version. See also scikit-quant/scikit-quant#24."

--- a/qiskit_algorithms/optimizers/spsa.py
+++ b/qiskit_algorithms/optimizers/spsa.py
@@ -629,7 +629,7 @@ class SPSA(Optimizer):
         logger.info("SPSA: Finished in %s", time() - start)
 
         if self.last_avg > 1:
-            x = np.mean(last_steps, axis=0)  # type: ignore[call-overload]
+            x = np.mean(np.asarray(last_steps), axis=0)
 
         result = OptimizerResult()
         result.x = x


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Closes #10

This removes the numpy constraints to < 1.25. The failure noted in #10 was the treatment of deprecation warnings as errors by the test base class brought over when the code was migrated here. That base class was changed. Deprecation warnings are now simply collected by CI and should be remedied, if caused by qiskit-algorithms code, by do not cause errors especially if these are emitted by 3rd party libraries. Running `test_imfil` indeed causes some deprecation messages to be emitted but code still works for now and passes the unit test.

```
.../SQImFil/_history.py:27: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
  fvalhist = float(fval)
.../SQImFil/_history.py:30: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
  histout.append([fcount, fvalhist, npgrad, stepn, iarm] + list(map(float, x)))
.../SQImFil/_exec_functions.py:156: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
  alist[i] = (x[i] > obounds[i,0]+epsb) and (x[i] < obounds[i,1]-epsb)
```  

When I was looking at the code I noticed the `snobfit.py` numpy version was how things were in the unit tests before #70 was done. So I updated this file along with the change which was basically to remove the constraint for numpy from `contraints.txt`. This left the file empty and while removing it completely would be an option I chose to leave it with a single line comment in there.

### Details and comments

Given this closes #10 I will create another issue to consider removing the scikit-quant optimizers here as the repo seems pretty much unmaintained with last activity 2 years ago and the snobfit issue /scikit-quant/scikit-quant#24, for which unit tests here are skipped, has been open and without any activity since it was created at the end of last year . Unlike when these optimizer "wrappers" were added, to conform to the base Optimizer class, there is now also Minimizer protocol and the optimizers can still be used directly via that say with a partial. 

_**Update**_: Created following new issue for scikit-quant optimizers as outlined above
* #84
