### PR TITLE
VarQTEResult missing from API ref.

### DIFF
--- a/qiskit_algorithms/__init__.py
+++ b/qiskit_algorithms/__init__.py
@@ -203,6 +203,7 @@ used to train Quantum Boltzmann Machine Neural Networks for example.
    TrotterQRTE
    VarQITE
    VarQRTE
+   VarQTEResult
 
 Variational Quantum Time Evolution
 ++++++++++++++++++++++++++++++++++


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

`VarQite` and `VarQrte` return a `VarQTETResult` but it was missing from the API ref. I added it so the result return from the `evolve` methods now can correctly link to this the result.

### Details and comments

I marked it for backport as we can re-publish the docs so as to update them to include this.
