### PR TITLE
Improve unit test

### DIFF
--- a/test/minimum_eigensolvers/test_vqe.py
+++ b/test/minimum_eigensolvers/test_vqe.py
@@ -81,9 +81,9 @@ class TestVQE(QiskitAlgorithmsTestCase):
         self.ry_wavefunction = TwoLocal(rotation_blocks="ry", entanglement_blocks="cz")
 
     @data(L_BFGS_B(), COBYLA())
-    def test_basic_aer_statevector(self, estimator):
+    def test_using_ref_estimator(self, optimizer):
         """Test VQE using reference Estimator."""
-        vqe = VQE(Estimator(), self.ryrz_wavefunction, estimator)
+        vqe = VQE(Estimator(), self.ryrz_wavefunction, optimizer)
 
         result = vqe.compute_minimum_eigenvalue(operator=self.h2_op)
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

I noticed that the VQE instance in a unit test seemed to be passed an estimator twice. The latter parameter named estimator was however an optimizer from the ddt data. Given it's confusing I changed the parameter name as well as the test case name which maybe more what it was in the past but is rather out of date now/


### Details and comments


