### PR TITLE
Fix Ci for latest mypy

### DIFF
--- a/qiskit_algorithms/minimum_eigensolvers/adapt_vqe.py
+++ b/qiskit_algorithms/minimum_eigensolvers/adapt_vqe.py
@@ -13,7 +13,6 @@
 """An implementation of the AdaptVQE algorithm."""
 from __future__ import annotations
 
-from collections.abc import Sequence
 from enum import Enum
 
 import re
@@ -130,13 +129,13 @@ class AdaptVQE(VariationalAlgorithm, MinimumEigensolver):
         self._excitation_pool: list[BaseOperator] = []
         self._excitation_list: list[BaseOperator] = []
 
-    @property  # type: ignore[override]
-    def initial_point(self) -> Sequence[float] | None:
+    @property
+    def initial_point(self) -> np.ndarray | None:
         """Returns the initial point of the internal :class:`~.VQE` solver."""
         return self.solver.initial_point
 
     @initial_point.setter
-    def initial_point(self, value: Sequence[float] | None) -> None:
+    def initial_point(self, value: np.ndarray | None) -> None:
         """Sets the initial point of the internal :class:`~.VQE` solver."""
         self.solver.initial_point = value
 
@@ -275,7 +274,7 @@ class AdaptVQE(VariationalAlgorithm, MinimumEigensolver):
             # setting up the ansatz for the VQE iteration
             self._tmp_ansatz.operators = self._excitation_list
             self.solver.ansatz = self._tmp_ansatz
-            self.solver.initial_point = theta
+            self.solver.initial_point = np.asarray(theta)
             # evaluating the eigenvalue with the internal VQE
             prev_raw_vqe_result = raw_vqe_result
             raw_vqe_result = self.solver.compute_minimum_eigenvalue(operator)
@@ -297,7 +296,7 @@ class AdaptVQE(VariationalAlgorithm, MinimumEigensolver):
                     theta.pop()
                     self._tmp_ansatz.operators = self._excitation_list
                     self.solver.ansatz = self._tmp_ansatz
-                    self.solver.initial_point = theta
+                    self.solver.initial_point = np.asarray(theta)
                     raw_vqe_result = prev_raw_vqe_result
                     break
             # appending the computed eigenvalue to the tracking history

--- a/qiskit_algorithms/minimum_eigensolvers/qaoa.py
+++ b/qiskit_algorithms/minimum_eigensolvers/qaoa.py
@@ -129,7 +129,7 @@ class QAOA(SamplingVQE):
             sampler=sampler,
             ansatz=None,
             optimizer=optimizer,
-            initial_point=initial_point,  # type: ignore[arg-type]
+            initial_point=initial_point,
             aggregation=aggregation,
             callback=callback,
         )

--- a/qiskit_algorithms/minimum_eigensolvers/sampling_vqe.py
+++ b/qiskit_algorithms/minimum_eigensolvers/sampling_vqe.py
@@ -225,7 +225,7 @@ class SamplingVQE(VariationalAlgorithm, SamplingMinimumEigensolver):
             optimizer_result = self.optimizer.minimize(
                 fun=evaluate_energy,  # type: ignore[arg-type]
                 x0=initial_point,
-                bounds=bounds
+                bounds=bounds,
             )
 
             # reset to original value

--- a/qiskit_algorithms/minimum_eigensolvers/sampling_vqe.py
+++ b/qiskit_algorithms/minimum_eigensolvers/sampling_vqe.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Sequence
+from collections.abc import Callable
 import logging
 from time import time
 from typing import Any
@@ -120,7 +120,7 @@ class SamplingVQE(VariationalAlgorithm, SamplingMinimumEigensolver):
         ansatz: QuantumCircuit,
         optimizer: Optimizer | Minimizer,
         *,
-        initial_point: Sequence[float] | None = None,
+        initial_point: np.ndarray | None = None,
         aggregation: float | Callable[[list[float]], float] | None = None,
         callback: Callable[[int, np.ndarray, float, dict[str, Any]], None] | None = None,
     ) -> None:
@@ -152,13 +152,13 @@ class SamplingVQE(VariationalAlgorithm, SamplingMinimumEigensolver):
         # this has to go via getters and setters due to the VariationalAlgorithm interface
         self._initial_point = initial_point
 
-    @property  # type: ignore[override]
-    def initial_point(self) -> Sequence[float] | None:
+    @property
+    def initial_point(self) -> np.ndarray | None:
         """Return the initial point."""
         return self._initial_point
 
     @initial_point.setter
-    def initial_point(self, value: Sequence[float] | None) -> None:
+    def initial_point(self, value: np.ndarray | None) -> None:
         """Set the initial point."""
         self._initial_point = value
 
@@ -212,8 +212,9 @@ class SamplingVQE(VariationalAlgorithm, SamplingMinimumEigensolver):
 
         if callable(self.optimizer):
             optimizer_result = self.optimizer(
-                fun=evaluate_energy,  # type: ignore[call-arg,arg-type]
-                x0=initial_point,  # type: ignore[arg-type]
+                fun=evaluate_energy,  # type: ignore[arg-type]
+                x0=initial_point,
+                jac=None,
                 bounds=bounds,
             )
         else:
@@ -222,7 +223,9 @@ class SamplingVQE(VariationalAlgorithm, SamplingMinimumEigensolver):
             was_updated = _set_default_batchsize(self.optimizer)
 
             optimizer_result = self.optimizer.minimize(
-                fun=evaluate_energy, x0=initial_point, bounds=bounds  # type: ignore[arg-type]
+                fun=evaluate_energy,  # type: ignore[arg-type]
+                x0=initial_point,
+                bounds=bounds
             )
 
             # reset to original value

--- a/qiskit_algorithms/minimum_eigensolvers/vqe.py
+++ b/qiskit_algorithms/minimum_eigensolvers/vqe.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import logging
 from time import time
-from collections.abc import Callable, Sequence
+from collections.abc import Callable
 from typing import Any
 
 import numpy as np
@@ -119,7 +119,7 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
         optimizer: Optimizer | Minimizer,
         *,
         gradient: BaseEstimatorGradient | None = None,
-        initial_point: Sequence[float] | None = None,
+        initial_point: np.ndarray | None = None,
         callback: Callable[[int, np.ndarray, float, dict[str, Any]], None] | None = None,
     ) -> None:
         r"""
@@ -150,12 +150,12 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
         self.initial_point = initial_point
         self.callback = callback
 
-    @property  # type: ignore[override]
-    def initial_point(self) -> Sequence[float] | None:
+    @property
+    def initial_point(self) -> np.ndarray | None:
         return self._initial_point
 
     @initial_point.setter
-    def initial_point(self, value: Sequence[float] | None) -> None:
+    def initial_point(self, value: np.ndarray | None) -> None:
         self._initial_point = value
 
     def compute_minimum_eigenvalue(
@@ -182,7 +182,7 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
         if callable(self.optimizer):
             optimizer_result = self.optimizer(
                 fun=evaluate_energy,  # type: ignore[arg-type]
-                x0=initial_point,  # type: ignore[arg-type]
+                x0=initial_point,
                 jac=evaluate_gradient,
                 bounds=bounds,
             )
@@ -193,7 +193,7 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
 
             optimizer_result = self.optimizer.minimize(
                 fun=evaluate_energy,  # type: ignore[arg-type]
-                x0=initial_point,  # type: ignore[arg-type]
+                x0=initial_point,
                 jac=evaluate_gradient,  # type: ignore[arg-type]
                 bounds=bounds,
             )

--- a/qiskit_algorithms/utils/validate_initial_point.py
+++ b/qiskit_algorithms/utils/validate_initial_point.py
@@ -14,8 +14,6 @@
 
 from __future__ import annotations
 
-from typing import cast, Sequence
-
 import numpy as np
 
 from qiskit.circuit import QuantumCircuit
@@ -23,8 +21,8 @@ from qiskit_algorithms.utils.algorithm_globals import algorithm_globals
 
 
 def validate_initial_point(
-    point: Sequence[float] | None, circuit: QuantumCircuit
-) -> Sequence[float]:
+    point: np.ndarray | None | None, circuit: QuantumCircuit
+) -> np.ndarray:
     r"""
     Validate a choice of initial point against a choice of circuit. If no point is provided, a
     random point will be generated within certain parameter bounds. It will first look to the
@@ -58,7 +56,7 @@ def validate_initial_point(
             upper_bounds.append(upper if upper is not None else 2 * np.pi)
 
         # sample from within bounds
-        point = cast(Sequence[float], algorithm_globals.random.uniform(lower_bounds, upper_bounds))
+        point = algorithm_globals.random.uniform(lower_bounds, upper_bounds)
 
     elif len(point) != expected_size:
         raise ValueError(

--- a/qiskit_algorithms/utils/validate_initial_point.py
+++ b/qiskit_algorithms/utils/validate_initial_point.py
@@ -20,9 +20,7 @@ from qiskit.circuit import QuantumCircuit
 from qiskit_algorithms.utils.algorithm_globals import algorithm_globals
 
 
-def validate_initial_point(
-    point: np.ndarray | None | None, circuit: QuantumCircuit
-) -> np.ndarray:
+def validate_initial_point(point: np.ndarray | None | None, circuit: QuantumCircuit) -> np.ndarray:
     r"""
     Validate a choice of initial point against a choice of circuit. If no point is provided, a
     random point will be generated within certain parameter bounds. It will first look to the


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

CI is failing here with the latest mypy (1.6.0). The issue seems to be around override in initial_point setter/getter.

In looking the base class defines the type as an optional numpy array. Yet we change things up to Sequence[float] in derived classes and then have to ignore the arg to minimize/optimize as that takes a POINT (union of numpy array or float). Given the initial point needs to line up with what is passed to optimizer, and scipy mimimize states it takes a numpy array (although internally it does as asarray() on whats passed) I have changed the type hints all over to np.ndarray from Sequence. QAOA initial_point was already a numpy array and that had an ignore in order to call the parent SamplingVQE that takes a Sequence.
As such I felt this was clearer/cleaner. People pass numpy arrays, or lists which will work.

For VQD what we have as initial_point is more initial_points which is somewhat at odds with it being a variational algo as that defines just an initial point really. I did not alter anything - I think this has been observed before, and arguably things ought to be improved at some point. And I will point out that type difference in the derived class, while mypy 1.6.0 does not object, mypy 1.,5..1 does which is presumably why those ignores were there elsewhere too.
```
qiskit_algorithms/eigensolvers/vqd.py:170: note:      Superclass:
qiskit_algorithms/eigensolvers/vqd.py:170: note:          Optional[ndarray[Any, Any]]
qiskit_algorithms/eigensolvers/vqd.py:170: note:      Subclass:
qiskit_algorithms/eigensolvers/vqd.py:170: note:          Union[ndarray[Any, Any], list[ndarray[Any, Any]], None]
```
Now I could have just left it ndarray but since the text talks about list of points I felt it was better to be explicit here and that things are different.


Since its only a change to typehints I did not do a reno. Users code, if it worked before should continue to work.

### Details and comments


