### PR TITLE
Fix ComputeUncompute State Fidelity threading issue

### DIFF
--- a/qiskit_algorithms/state_fidelities/base_state_fidelity.py
+++ b/qiskit_algorithms/state_fidelities/base_state_fidelity.py
@@ -23,7 +23,6 @@ from qiskit import QuantumCircuit
 from qiskit.circuit import ParameterVector
 
 from ..algorithm_job import AlgorithmJob
-from .state_fidelity_result import StateFidelityResult
 
 
 class BaseStateFidelity(ABC):
@@ -246,7 +245,7 @@ class BaseStateFidelity(ABC):
         values_1: Sequence[float] | Sequence[Sequence[float]] | None = None,
         values_2: Sequence[float] | Sequence[Sequence[float]] | None = None,
         **options,
-    ) -> StateFidelityResult:
+    ) -> AlgorithmJob:
         r"""
         Computes the state overlap (fidelity) calculation between two
         (parametrized) circuits (first and second) for a specific set of parameter
@@ -263,7 +262,7 @@ class BaseStateFidelity(ABC):
                 Higher priority setting overrides lower priority setting.
 
         Returns:
-            The result of the fidelity calculation.
+            A newly constructed algorithm job instance to get the fidelity result.
         """
         raise NotImplementedError
 
@@ -293,15 +292,15 @@ class BaseStateFidelity(ABC):
 
         Returns:
             Primitive job for the fidelity calculation.
-            The job's result is an instance of ``StateFidelityResult``.
+            The job's result is an instance of :class:`.StateFidelityResult`.
         """
-
-        job = AlgorithmJob(self._run, circuits_1, circuits_2, values_1, values_2, **options)
+        job = self._run(circuits_1, circuits_2, values_1, values_2, **options)
 
         job.submit()
         return job
 
-    def _truncate_fidelities(self, fidelities: Sequence[float]) -> Sequence[float]:
+    @staticmethod
+    def _truncate_fidelities(fidelities: Sequence[float]) -> Sequence[float]:
         """
         Ensures fidelity result in [0,1].
 

--- a/qiskit_algorithms/state_fidelities/compute_uncompute.py
+++ b/qiskit_algorithms/state_fidelities/compute_uncompute.py
@@ -137,7 +137,7 @@ class ComputeUncompute(BaseStateFidelity):
                     Higher priority setting overrides lower priority setting.
 
         Returns:
-            An AlgorithmJOb for the fidelity calculation.
+            An AlgorithmJob for the fidelity calculation.
 
         Raises:
             ValueError: At least one pair of circuits must be defined.

--- a/releasenotes/notes/fix-fidelity-00fbfa9919e860de.yaml
+++ b/releasenotes/notes/fix-fidelity-00fbfa9919e860de.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixes state fidelity :class:`.ComputeUncompute` to correct an issue arising from
+    the threading used for the job result. This issue could be seen sometimes if more
+    than one job was created and their results fetched back-to-back, such that more than
+    one internal thread was active processing these results.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes #91

- [x] Add reno (as noted below)

### Details and comments

I changed the logic so that the `sampler.run` is done in the main thread and the resulting job and result is processed for the fidelity result in a separate method that is run by the thread executor of the algorithm job. This new method (_call which I named to be the same as the ref. primitives) gets passed all it needs as params, self is not passed, and where that logic was using some private instance utility methods I turned these to static (they never used self anyway).

As far as an end user goes the ComputeUncompute is used just the same way. As I changed things around a little bit though any developer that might have extended the base class, for some custom fidelity, would need to update their code for the _run. 

I kept the changes minimal though the presence of the _run is a little harder to justify as things are now, but I figure, if more fidelities are added going forwards that may be a better time to sort out commonality than change things around more now.

I'll add a reno once others have had a chance to look over this. It would note the bug fix and point out the change to _run should anyone happen to have made their own fidelity off the base.