### PR TITLE
Fix State Fidelity cache key

### DIFF
--- a/qiskit_algorithms/state_fidelities/base_state_fidelity.py
+++ b/qiskit_algorithms/state_fidelities/base_state_fidelity.py
@@ -21,6 +21,7 @@ import numpy as np
 
 from qiskit import QuantumCircuit
 from qiskit.circuit import ParameterVector
+from qiskit.primitives.utils import _circuit_key
 
 from ..algorithm_job import AlgorithmJob
 from .state_fidelity_result import StateFidelityResult
@@ -173,8 +174,8 @@ class BaseStateFidelity(ABC):
         circuits = []
         for (circuit_1, circuit_2) in zip(circuits_1, circuits_2):
 
-            # TODO: improve caching, what if the circuit is modified without changing the id?
-            circuit = self._circuit_cache.get((id(circuit_1), id(circuit_2)))
+            # Use the same key for circuits as qiskit.primitives use.
+            circuit = self._circuit_cache.get((_circuit_key(circuit_1), _circuit_key(circuit_2)))
 
             if circuit is not None:
                 circuits.append(circuit)
@@ -193,7 +194,7 @@ class BaseStateFidelity(ABC):
                 )
                 circuits.append(circuit)
                 # update cache
-                self._circuit_cache[id(circuit_1), id(circuit_2)] = circuit
+                self._circuit_cache[_circuit_key(circuit_1), _circuit_key(circuit_2)] = circuit
 
         return circuits
 

--- a/releasenotes/notes/fix_fidelity_cache-3a4cc328344716e0.yaml
+++ b/releasenotes/notes/fix_fidelity_cache-3a4cc328344716e0.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixes internal cache used by state fidelities so that circuits are cached
+    using the same generated key method as that used by the reference primitives.
+    This avoids a potential incorrect result that could have occurred with the
+    key as it was before when id() was used.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes #90

### Details and comments

Switches from `id()` to `_circuit_key()` where the latter is that which the reference primitives use. Using id() is problematic, as #90 notes, though `_circuit_key` is designated a private method, and while its the better choice functionally, it feels a bit off to be using what is designated a private method. Its been used/stable for a while though. A choice might be to copy the whole routine here - but perhaps better to see if this changes going forwards in the way some unique key/hash can be obtained for a circuit.

