### PR TITLE
Fix GSLS optimizer bounds if entries have None

### DIFF
--- a/qiskit_algorithms/optimizers/gsls.py
+++ b/qiskit_algorithms/optimizers/gsls.py
@@ -119,8 +119,8 @@ class GSLS(Optimizer):
             var_lb = np.array([-np.inf] * x0.size)
             var_ub = np.array([np.inf] * x0.size)
         else:
-            var_lb = np.array([l for (l, _) in bounds])
-            var_ub = np.array([u for (_, u) in bounds])
+            var_lb = np.array([l if l is not None else -np.inf for (l, _) in bounds])
+            var_ub = np.array([u if u is not None else np.inf for (_, u) in bounds])
 
         x, fun_, nfev, _ = self.ls_optimize(x0.size, fun, x0, var_lb, var_ub)
 

--- a/releasenotes/notes/fix_gsls_bounds-29d4a7506130cd69.yaml
+++ b/releasenotes/notes/fix_gsls_bounds-29d4a7506130cd69.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixes :class:`.GSLS` optimizer :meth:`~.GSLS.minimize` so that if the ``bounds`` parameter
+    is passed with tuples that have entries of ``None`` then the entry is treated
+    as equivalent to infinity.

--- a/test/optimizers/test_optimizers.py
+++ b/test/optimizers/test_optimizers.py
@@ -160,6 +160,13 @@ class TestOptimizers(QiskitAlgorithmsTestCase):
         self.assertLessEqual(x_value, 0.01)
         self.assertLessEqual(n_evals, 10000)
 
+        with self.subTest("Bounds (None, None)"):
+            algorithm_globals.random_seed = 1
+            res = optimizer.minimize(rosen, x_0, bounds=[(None, None)] * len(x_0))
+
+            self.assertLessEqual(res.fun, 0.01)
+            self.assertLessEqual(res.nfev, 10000)
+
     def test_scipy_optimizer(self):
         """scipy_optimizer test"""
         optimizer = SciPyOptimizer("BFGS", options={"maxiter": 1000})


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes #94

### Details and comments

When the optimizer creates its upper and lower bound arrays, any None entrys are replaced by infinity (i.e. No bound)
