### PR TITLE
Update CI to use latest windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -117,9 +117,9 @@ jobs:
             python-version: 3.8
           - os: macos-latest
             python-version: 3.11
-          - os: windows-2019
+          - os: windows-latest
             python-version: 3.8
-          - os: windows-2019
+          - os: windows-latest
             python-version: 3.11
     steps:
       - uses: actions/checkout@v3
@@ -249,11 +249,11 @@ jobs:
           path: /tmp/m311
       - uses: actions/download-artifact@v3
         with:
-          name: windows-2019-3.8
+          name: windows-latest-3.8
           path: /tmp/w38
       - uses: actions/download-artifact@v3
         with:
-          name: windows-2019-3.11
+          name: windows-latest-3.11
           path: /tmp/w311
       - name: Install Dependencies
         run: pip install -U coverage coveralls diff-cover


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Changed windows-2019 to windows-latest (current same as windows-2022) so it running on a newer version and use latest like is done on others. My recollection of it using windows-2019 specifically was when Aer was being built from source. As this is no longer the case it seems better to switch to a newer version and do -latest like is done with Ubuntu and Mac

I already did this in Nature https://github.com/qiskit-community/qiskit-nature/pull/1266 as part of updating CI there.

### Details and comments

The branch rules will need updating to account for the job name change.
