### PR TITLE
Fix CI failure with Qiskit 0.45 - Trotter QDrift test

### DIFF
--- a/test/time_evolvers/test_trotter_qrte.py
+++ b/test/time_evolvers/test_trotter_qrte.py
@@ -175,8 +175,7 @@ class TestTrotterQRTE(QiskitAlgorithmsTestCase):
         time = 1
         evolution_problem = TimeEvolutionProblem(operator, time, initial_state)
 
-        algorithm_globals.random_seed = 0
-        trotter_qrte = TrotterQRTE(product_formula=QDrift())
+        trotter_qrte = TrotterQRTE(product_formula=QDrift(seed=0))
 
         evolution_result = trotter_qrte.evolve(evolution_problem)
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

QDrift is now independently seeded in Qiskit 0.45. It used to be seeded from algorithms_globals but with that being deprecated from Qiskit, and moved here, the RNG and seed it used had to change. This changes the failing test to directly seed QDrift rather than do it via algorithm_globals as had been done before. This makes that test dependent on the latest Qiskit though - I think this is ok though.

### Details and comments


