### PR TITLE
Update Diagonal Estimator for Qiskit change

### DIFF
--- a/qiskit_algorithms/minimum_eigensolvers/diagonal_estimator.py
+++ b/qiskit_algorithms/minimum_eigensolvers/diagonal_estimator.py
@@ -20,7 +20,7 @@ from typing import Any
 from dataclasses import dataclass
 
 import numpy as np
-from qiskit.circuit import QuantumCircuit, Pa
+from qiskit.circuit import QuantumCircuit
 from qiskit.primitives import BaseSampler, BaseEstimator, EstimatorResult
 from qiskit.primitives.utils import init_observable, _circuit_key
 from qiskit.quantum_info import SparsePauliOp

--- a/qiskit_algorithms/minimum_eigensolvers/diagonal_estimator.py
+++ b/qiskit_algorithms/minimum_eigensolvers/diagonal_estimator.py
@@ -59,6 +59,10 @@ class _DiagonalEstimator(BaseEstimator):
 
         """
         super().__init__(options=options)
+        self._circuits = []  # See Qiskit pull request 11051
+        self._parameters = []
+        self._observables = []
+
         self.sampler = sampler
         if not callable(aggregation):
             aggregation = _get_cvar_aggregation(aggregation)

--- a/qiskit_algorithms/minimum_eigensolvers/diagonal_estimator.py
+++ b/qiskit_algorithms/minimum_eigensolvers/diagonal_estimator.py
@@ -14,13 +14,13 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Sequence, Mapping, Iterable
+from collections.abc import Callable, Sequence, Mapping, Iterable, MappingView
 from typing import Any
 
 from dataclasses import dataclass
 
 import numpy as np
-from qiskit.circuit import QuantumCircuit
+from qiskit.circuit import QuantumCircuit, Pa
 from qiskit.primitives import BaseSampler, BaseEstimator, EstimatorResult
 from qiskit.primitives.utils import init_observable, _circuit_key
 from qiskit.quantum_info import SparsePauliOp
@@ -59,9 +59,9 @@ class _DiagonalEstimator(BaseEstimator):
 
         """
         super().__init__(options=options)
-        self._circuits = []  # See Qiskit pull request 11051
-        self._parameters = []
-        self._observables = []
+        self._circuits: list[QuantumCircuit] = []  # See Qiskit pull request 11051
+        self._parameters: list[MappingView] = []
+        self._observables: list[SparsePauliOp] = []
 
         self.sampler = sampler
         if not callable(aggregation):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The primitives are being altered in Qiskit where Qiskit/qiskit#11051 removed attributes from the base classes which affected sub-classes using these. In such subclasses, the diagonal estimator in algorithms still there in Qiskit, corresponding private attributes were added to these. This mirrors the same change - it should be compatible with current Qiskit base estimator too as this same code is there in the constructor, so while its done twice now in the future this will be needed. Things may be further refactored for the primitives but this keeps things updated for now.

### Details and comments


