### PR TITLE
Update requirements to `qiskit` instead of `qiskit-terra`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-qiskit-terra>=0.24
+qiskit>=0.44
 scipy>=1.4
 numpy>=1.17


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

While doing the recent changes I did I noticed that requirements still is depending on `qiskit-terra` so this updates that and switches it to `qiskit`.

### Details and comments


