### PR TITLE
Add unit test jobs with Qiskit main

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -167,7 +167,7 @@ jobs:
           path: ./ci-artifact-data/*
   Monitor_Qiskit_Main:
     if: (github.repository_owner == 'qiskit-community') &&
-        (startsWith(github.ref, 'refs/heads/main') || startsWith(github.base_ref, 'main/'))
+        ${{ startsWith(github.ref, 'refs/heads/main') || startsWith(github.base_ref, 'main/') }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -166,8 +166,7 @@ jobs:
           name: ${{ matrix.os }}-${{ matrix.python-version }}
           path: ./ci-artifact-data/*
   Monitor_Qiskit_Main:
-    if: ${{ (github.repository_owner == 'qiskit-community') &&
-      ((github.ref == 'refs/heads/main') || (github.base_ref == 'main/')) }}
+    if: ${{ (github.repository_owner == 'qiskit-community') && ((github.ref == 'refs/heads/main') || (github.base_ref == 'main/')) }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -167,7 +167,7 @@ jobs:
           path: ./ci-artifact-data/*
   Monitor_Qiskit_Main:
     if: (github.repository_owner == 'qiskit-community') &&
-        (startsWith(github.ref, 'refs/heads/mainx') || startsWith(github.base_ref, 'mainx/'))
+        (startsWith(github.ref, 'refs/heads/main') || startsWith(github.base_ref, 'main/'))
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -166,7 +166,7 @@ jobs:
           name: ${{ matrix.os }}-${{ matrix.python-version }}
           path: ./ci-artifact-data/*
   Monitor_Qiskit_Main:
-    if: github.repository_owner == 'qiskit-community' && (github.ref == 'refs/heads/mainx' || github.base_ref == 'mainx')
+    if: github.repository_owner == 'qiskit-community' && (github.ref == 'refs/heads/main' || github.base_ref == 'main')
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -167,7 +167,7 @@ jobs:
           path: ./ci-artifact-data/*
   Monitor_Qiskit_Main:
     if: (github.repository_owner == 'qiskit-community') &&
-        ${{ startsWith(github.ref, 'refs/heads/main') || startsWith(github.base_ref, 'main/') }}
+        ${{ startsWith(github.ref, 'refs/heads/mainx') || startsWith(github.base_ref, 'mainx/') }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -166,8 +166,8 @@ jobs:
           name: ${{ matrix.os }}-${{ matrix.python-version }}
           path: ./ci-artifact-data/*
   Monitor_Qiskit_Main:
-    if: (github.repository_owner == 'qiskit-community') &&
-        (startsWith(github.ref, 'refs/heads/main') || startsWith(github.base_ref, 'main/'))
+    if: ${{ (github.repository_owner == 'qiskit-community') &&
+        (startsWith(github.ref, 'refs/heads/main') || startsWith(github.base_ref, 'main/')) }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -135,6 +135,7 @@ jobs:
         with:
           os: ${{ matrix.os }}
           python-version: ${{ matrix.python-version }}
+          terra-main: "false"
         if: ${{ !startsWith(github.ref, 'refs/heads/stable') && !startsWith(github.base_ref, 'stable/') }}
       - uses: ./.github/actions/install-algorithms
       - run: make lint
@@ -164,6 +165,43 @@ jobs:
         with:
           name: ${{ matrix.os }}-${{ matrix.python-version }}
           path: ./ci-artifact-data/*
+  Monitor_Qiskit_Main:
+    if: github.repository_owner == 'qiskit-community'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        python-version: [3.8, 3.11]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+          cache-dependency-path: |
+            setup.py
+            requirements.txt
+            requirements-dev.txt
+      - uses: ./.github/actions/install-main-dependencies
+        with:
+          os: ${{ matrix.os }}
+          python-version: ${{ matrix.python-version }}
+          terra-main: "true"
+        if: ${{ !startsWith(github.ref, 'refs/heads/stable') && !startsWith(github.base_ref, 'stable/') }}
+      - uses: ./.github/actions/install-algorithms
+      - run: make lint
+        shell: bash
+      - run: make mypy
+        shell: bash
+      - name: Algorithms Unit Tests under Python with Qiskit main ${{ matrix.python-version }}
+        uses: ./.github/actions/run-tests
+        with:
+          os: ${{ matrix.os }}
+          event-name: ${{ github.event_name }}
+          run-slow: ${{ contains(github.event.pull_request.labels.*.name, 'run_slow') }}
+          python-version: ${{ matrix.python-version }}
+        if: ${{ !cancelled() }}
   Tutorials:
     if: github.repository_owner == 'qiskit-community'
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -167,7 +167,7 @@ jobs:
           path: ./ci-artifact-data/*
   Monitor_Qiskit_Main:
     if: (github.repository_owner == 'qiskit-community') &&
-        ${{ startsWith(github.ref, 'refs/heads/mainx') || startsWith(github.base_ref, 'mainx/') }}
+        (startsWith(github.ref, 'refs/heads/mainx') || startsWith(github.base_ref, 'mainx/'))
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -167,7 +167,7 @@ jobs:
           path: ./ci-artifact-data/*
   Monitor_Qiskit_Main:
     if: ${{ (github.repository_owner == 'qiskit-community') &&
-        (startsWith(github.ref, 'refs/heads/main') || startsWith(github.base_ref, 'main/')) }}
+      ((github.ref == 'refs/heads/main') || (github.base_ref == 'main/')) }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -167,7 +167,7 @@ jobs:
           path: ./ci-artifact-data/*
   Monitor_Qiskit_Main:
     if: github.repository_owner == 'qiskit-community' &&
-        (startsWith(github.ref, 'refs/heads/mainx') || startsWith(github.base_ref, 'mainx/'))
+        (startsWith(github.ref, 'refs/heads/main') || startsWith(github.base_ref, 'main/'))
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -166,7 +166,7 @@ jobs:
           name: ${{ matrix.os }}-${{ matrix.python-version }}
           path: ./ci-artifact-data/*
   Monitor_Qiskit_Main:
-    if: ${{ (github.repository_owner == 'qiskit-community') && ((github.ref == 'refs/heads/main') || (github.base_ref == 'main/')) }}
+    if: github.repository_owner == 'qiskit-community' && (github.ref == 'refs/heads/main' || github.base_ref == 'main/')
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -166,7 +166,7 @@ jobs:
           name: ${{ matrix.os }}-${{ matrix.python-version }}
           path: ./ci-artifact-data/*
   Monitor_Qiskit_Main:
-    if: github.repository_owner == 'qiskit-community' && github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -166,7 +166,7 @@ jobs:
           name: ${{ matrix.os }}-${{ matrix.python-version }}
           path: ./ci-artifact-data/*
   Monitor_Qiskit_Main:
-    if: github.repository_owner == 'qiskit-community' && (github.ref == 'refs/heads/main' || github.base_ref == 'main/')
+    if: github.repository_owner == 'qiskit-community' && github.ref == 'refs/heads/main'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -166,7 +166,7 @@ jobs:
           name: ${{ matrix.os }}-${{ matrix.python-version }}
           path: ./ci-artifact-data/*
   Monitor_Qiskit_Main:
-    if: github.repository_owner == 'qiskit-community' && (github.ref == 'refs/heads/main' || github.base_ref == 'main')
+    if: github.repository_owner == 'qiskit-community' && (github.ref == 'refs/heads/mainx' || github.base_ref == 'mainx')
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -166,7 +166,7 @@ jobs:
           name: ${{ matrix.os }}-${{ matrix.python-version }}
           path: ./ci-artifact-data/*
   Monitor_Qiskit_Main:
-    if: github.repository_owner == 'qiskit-community' &&
+    if: (github.repository_owner == 'qiskit-community') &&
         (startsWith(github.ref, 'refs/heads/main') || startsWith(github.base_ref, 'main/'))
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -166,7 +166,7 @@ jobs:
           name: ${{ matrix.os }}-${{ matrix.python-version }}
           path: ./ci-artifact-data/*
   Monitor_Qiskit_Main:
-    if: github.ref == 'refs/heads/main'
+    if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -166,7 +166,8 @@ jobs:
           name: ${{ matrix.os }}-${{ matrix.python-version }}
           path: ./ci-artifact-data/*
   Monitor_Qiskit_Main:
-    if: github.repository_owner == 'qiskit-community'
+    if: github.repository_owner == 'qiskit-community' &&
+        (startsWith(github.ref, 'refs/heads/mainx') || startsWith(github.base_ref, 'mainx/'))
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -188,7 +189,6 @@ jobs:
           os: ${{ matrix.os }}
           python-version: ${{ matrix.python-version }}
           terra-main: "true"
-        if: ${{ !startsWith(github.ref, 'refs/heads/stable') && !startsWith(github.base_ref, 'stable/') }}
       - uses: ./.github/actions/install-algorithms
       - run: make lint
         shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -166,7 +166,7 @@ jobs:
           name: ${{ matrix.os }}-${{ matrix.python-version }}
           path: ./ci-artifact-data/*
   Monitor_Qiskit_Main:
-    if: github.repository_owner == 'qiskit-community'
+    if: github.repository_owner == 'qiskit-community' && (github.ref == 'refs/heads/main' || github.base_ref == 'main')
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -189,9 +189,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
           terra-main: "true"
       - uses: ./.github/actions/install-algorithms
-      - run: |
-          echo ${{ github.ref }}
-          echo ${{ github.base_ref }}
       - run: make lint
         shell: bash
       - run: make mypy

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -166,7 +166,7 @@ jobs:
           name: ${{ matrix.os }}-${{ matrix.python-version }}
           path: ./ci-artifact-data/*
   Monitor_Qiskit_Main:
-    if: ${{ github.ref == 'refs/heads/main' }}
+    if: github.repository_owner == 'qiskit-community'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -189,6 +189,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
           terra-main: "true"
       - uses: ./.github/actions/install-algorithms
+      - run: |
+          echo ${{ github.ref }}
+          echo ${{ github.base_ref }}
       - run: make lint
         shell: bash
       - run: make mypy


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Adds jobs (Ubuntu at min/max python supported versions - 3.8 and 3.11) which test Qiskit Algorithms against Qsikit main dev branch to give insight into into any breaking changes. Breaking changes are expected in Qiskit 1.0 so this will enable monitoring of the main dev branch to see if any failures occur that do not against the stable released version used elsewhere in the main tests here.

These new jobs will not be added to the branch rules but its expected that failures be investigated and action taken accordingly. Not all failures may be compatibility/breaking changes but may be due to the fact the Qiskit CI has occasional failures, say due to changes in dependents, but the reason can be uncovered by investigating the build output from the jobs etc.

### Details and comments

As this is more to monitor things I chose to not create any artifacts from these jobs, rather as the log files themselves can be consulted.

The logic in this new section is much like the main Algorithms section but cut down on the matrix, uses Qiskit main rather than stable, and no deprecation extraction, coverage or atrifacts uploaded. 