### PR TITLE
Add Python 3.12 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -111,16 +111,16 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.8, 3.9, '3.10', 3.11]
+        python-version: [3.8, 3.9, '3.10', 3.11, 3.12]
         include:
           - os: macos-latest
             python-version: 3.8
           - os: macos-latest
-            python-version: 3.11
+            python-version: 3.12
           - os: windows-latest
             python-version: 3.8
           - os: windows-latest
-            python-version: 3.11
+            python-version: 3.12
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -172,7 +172,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.8, 3.11]
+        python-version: [3.8, 3.12]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -208,7 +208,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.8, 3.11]
+        python-version: [3.8, 3.12]
     steps:
       - uses: actions/checkout@v3
         with:
@@ -278,26 +278,30 @@ jobs:
           path: /tmp/u311
       - uses: actions/download-artifact@v3
         with:
+          name: ubuntu-latest-3.12
+          path: /tmp/u312
+      - uses: actions/download-artifact@v3
+        with:
           name: macos-latest-3.8
           path: /tmp/m38
       - uses: actions/download-artifact@v3
         with:
-          name: macos-latest-3.11
-          path: /tmp/m311
+          name: macos-latest-3.12
+          path: /tmp/m312
       - uses: actions/download-artifact@v3
         with:
           name: windows-latest-3.8
           path: /tmp/w38
       - uses: actions/download-artifact@v3
         with:
-          name: windows-latest-3.11
-          path: /tmp/w311
+          name: windows-latest-3.12
+          path: /tmp/w312
       - name: Install Dependencies
         run: pip install -U coverage coveralls diff-cover
         shell: bash
       - name: Combined Deprecation Messages
         run: |
-          sort -f -u /tmp/u38/alg.dep /tmp/u39/alg.dep /tmp/u310/alg.dep /tmp/u311/alg.dep /tmp/m38/alg.dep /tmp/m311/alg.dep /tmp/w38/alg.dep /tmp/w311/alg.dep || true
+          sort -f -u /tmp/u38/alg.dep /tmp/u39/alg.dep /tmp/u310/alg.dep /tmp/u311/alg.dep /tmp/u312/alg.dep /tmp/m38/alg.dep /tmp/m312/alg.dep /tmp/w38/alg.dep /tmp/w312/alg.dep || true
         shell: bash
       - name: Coverage combine
         run: coverage3 combine /tmp/u38/alg.dat

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -120,7 +120,7 @@ jobs:
           - os: windows-latest
             python-version: 3.8
           - os: windows-latest
-            python-version: 3.12
+            python-version: 3.11
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -294,14 +294,14 @@ jobs:
           path: /tmp/w38
       - uses: actions/download-artifact@v3
         with:
-          name: windows-latest-3.12
-          path: /tmp/w312
+          name: windows-latest-3.11
+          path: /tmp/w311
       - name: Install Dependencies
         run: pip install -U coverage coveralls diff-cover
         shell: bash
       - name: Combined Deprecation Messages
         run: |
-          sort -f -u /tmp/u38/alg.dep /tmp/u39/alg.dep /tmp/u310/alg.dep /tmp/u311/alg.dep /tmp/u312/alg.dep /tmp/m38/alg.dep /tmp/m312/alg.dep /tmp/w38/alg.dep /tmp/w312/alg.dep || true
+          sort -f -u /tmp/u38/alg.dep /tmp/u39/alg.dep /tmp/u310/alg.dep /tmp/u311/alg.dep /tmp/u312/alg.dep /tmp/m38/alg.dep /tmp/m312/alg.dep /tmp/w38/alg.dep /tmp/w311/alg.dep || true
         shell: bash
       - name: Coverage combine
         run: coverage3 combine /tmp/u38/alg.dat

--- a/releasenotes/notes/py_3_12_support-13aa1a32494d25e7.yaml
+++ b/releasenotes/notes/py_3_12_support-13aa1a32494d25e7.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Added support for using Qiskit Algorithms with Python 3.12.

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Topic :: Scientific/Engineering",
     ],
     keywords="qiskit sdk quantum algorithms",


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Given Qiskit 0.45.1 just released with Python 3.12 support I have added that here to Algorithms. 

### Details and comments

I added a new Ubuntu 3.12 run so that OS spans all the versions. I changed Mac and Windows to 3.12 from 3.11 so it tests the min and max versions supported now (just as it did before when 3.11 was the max). I did the same for Qiskit Main monitoring.

FYI I do not have 3.12 locally at present to check things so we'll see how it goes here...

- [ ] This will of course need the branch protection rules changing.


