### PR TITLE
Run CI tests using Python 3.12.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2023.
+# (C) Copyright IBM 2021, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -111,12 +111,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.8, 3.9, '3.10', 3.11, 3.12]
+        python-version: [3.8, 3.9, '3.10', 3.11, 3.12.0]
         include:
           - os: macos-latest
             python-version: 3.8
           - os: macos-latest
-            python-version: 3.12
+            python-version: 3.12.0
           - os: windows-latest
             python-version: 3.8
           - os: windows-latest
@@ -172,7 +172,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.8, 3.12]
+        python-version: [3.8, 3.12.0]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -278,7 +278,7 @@ jobs:
           path: /tmp/u311
       - uses: actions/download-artifact@v3
         with:
-          name: ubuntu-latest-3.12
+          name: ubuntu-latest-3.12.0
           path: /tmp/u312
       - uses: actions/download-artifact@v3
         with:
@@ -286,7 +286,7 @@ jobs:
           path: /tmp/m38
       - uses: actions/download-artifact@v3
         with:
-          name: macos-latest-3.12
+          name: macos-latest-3.12.0
           path: /tmp/m312
       - uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Ci fails some unit testing when using the latest Python 3.12.1 (CI just had 3.12 so pulls this in). This changes to explicitly use 3.12.0 to avoid the unit testing problem as per issue #113 I will leave #113 open so this pinning to 3.12.0 can be reverted once that is fixed. 


### Details and comments


