### PR TITLE
Fix calling deprecated submit()

### DIFF
--- a/.pylintdict
+++ b/.pylintdict
@@ -329,6 +329,7 @@ steppable
 stepsize
 str
 subcircuits
+subclassed
 subclasses
 subcomponents
 subspaces

--- a/qiskit_algorithms/algorithm_job.py
+++ b/qiskit_algorithms/algorithm_job.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2023.
+# (C) Copyright IBM 2022, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -18,7 +18,28 @@ from qiskit.primitives.primitive_job import PrimitiveJob
 
 class AlgorithmJob(PrimitiveJob):
     """
-    This empty class is introduced for typing purposes.
+    This class is introduced for typing purposes and provides no
+    additional function beyond that inherited from its parents.
+
+    Update: :meth:`AlgorithmJob.submit()` method added. See its
+    documentation for more info.
     """
 
-    pass
+    def submit(self) -> None:
+        """
+        Submit the job for execution.
+
+        For V1 primitives, Qiskit ``PrimitiveJob`` subclassed JobV1 and defined ``submit()``.
+        ``PrimitiveJob`` was updated for V2 primitives, no longer subclasses ``JobV1``, and
+        now has a private ``_submit()`` method, with ``submit()`` being deprecated as of
+        Qiskit version 0.46. This maintains the ``submit()`` for ``AlgorithmJob`` here as
+        it's called in many places for such a job. An alternative could be to make
+        0.46 the required minimum version and alter all algorithm's call sites to use
+        ``_submit()`` and make this an empty class again as it once was. For now this
+        way maintains compatibility with the current min version of 0.44.
+        """
+        # TODO: Considering changing this in the future - see above docstring.
+        try:
+            super()._submit()
+        except AttributeError:
+            super().submit()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Resolves #126

### Details and comments

I chose to do this in a way that's compatible with the currently defined min Qiskit version and avoids deprecation warnings for future versions where in PrimitiveJob its now `_submit()`

I altered the text about `an empty class` its no longer true when looking at the source, and in the docs it not appear that way at all anyway since it showed all the inherited methods. I also added a note about the why submit() exists in it now and a TODO as a reminder to potentially revisit this in the future.
