### PR TITLE
Update Win CI max ver to 3.12 now Aer supports 3.12

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -120,7 +120,7 @@ jobs:
           - os: windows-latest
             python-version: 3.8
           - os: windows-latest
-            python-version: 3.11
+            python-version: 3.12.0
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -294,14 +294,14 @@ jobs:
           path: /tmp/w38
       - uses: actions/download-artifact@v3
         with:
-          name: windows-latest-3.11
-          path: /tmp/w311
+          name: windows-latest-3.12.0
+          path: /tmp/w312
       - name: Install Dependencies
         run: pip install -U coverage coveralls diff-cover
         shell: bash
       - name: Combined Deprecation Messages
         run: |
-          sort -f -u /tmp/u38/alg.dep /tmp/u39/alg.dep /tmp/u310/alg.dep /tmp/u311/alg.dep /tmp/u312/alg.dep /tmp/m38/alg.dep /tmp/m312/alg.dep /tmp/w38/alg.dep /tmp/w311/alg.dep || true
+          sort -f -u /tmp/u38/alg.dep /tmp/u39/alg.dep /tmp/u310/alg.dep /tmp/u311/alg.dep /tmp/u312/alg.dep /tmp/m38/alg.dep /tmp/m312/alg.dep /tmp/w38/alg.dep /tmp/w312/alg.dep || true
         shell: bash
       - name: Coverage combine
         run: coverage3 combine /tmp/u38/alg.dat


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Qiskit Aer recently released 0.13.2 which now supports Python 3.12 so that wheels are available and it does not need to get built locally. This allows up to bump the Windows CI max Python version in which we test from 3.11 to 3.12 to be the same as Ubuntu and MacOS.

Resolves #109

### Details and comments

While this changed to 3.12 it is actually specifically 3.12.0 (same as other platforms) until #113 is addressed (i.e. when an updated testtools is released).

This will require branch rules to be updated since the Required Win 3.11 job will no longer happen with this change. i.e.
   - Algorithms (windows-latest, 3.11):   _Remove_
   - Algorithms (windows-latest, 3.12.0):  _Make Required_

