### PR TITLE
Fix dates from recent merge of #116

### DIFF
--- a/qiskit_algorithms/optimizers/aqgd.py
+++ b/qiskit_algorithms/optimizers/aqgd.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2019, 2023.
+# (C) Copyright IBM 2019, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/optimizers/test_optimizer_aqgd.py
+++ b/test/optimizers/test_optimizer_aqgd.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2019, 2023
+# (C) Copyright IBM 2019, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

#116 was done at the end of last year and the copyright dates passed through CI fine such that it merged. The merge run failed though https://github.com/qiskit-community/qiskit-algorithms/actions/runs/7658685508 due to the merge now being in 2024 and the files in main updated by merging the remote changes. This then led to failure of #128 when the branch was updated there.

This alters the dates to 2024 so CI will pass again.

### Details and comments


