### PR TITLE
Update intersphinx links and others

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2023.
+# (C) Copyright IBM 2023, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -122,7 +122,7 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "numpy": ("https://numpy.org/doc/stable", None),
     "scipy": ("https://docs.scipy.org/doc/scipy", None),
-    "qiskit": ("https://qiskit.org/documentation/", None),
+    "qiskit": ("https://docs.quantum.ibm.com/api/qiskit/", None),
 }
 
 # -- Options for HTML output -------------------------------------------------

--- a/docs/tutorials/01_algorithms_introduction.ipynb
+++ b/docs/tutorials/01_algorithms_introduction.ipynb
@@ -15,7 +15,7 @@
    "source": [
     "## How is the algorithm library structured?\n",
     "\n",
-    "`qiskit_algorithms` provides a number of [algorithms](https://qiskit.org/ecosystem/algorithms/apidocs/algorithms.html) grouped by category, according to the task they can perform. For instance `Minimum Eigensolvers` to find the smallest eigen value of an operator, for example ground state energy of a chemistry Hamiltonian or a solution to an optimization problem when expressed as an Ising Hamiltonian. There are `Time Evolvers` for the time evolution of quantum systems and `Amplitude Estimators` for value estimation that can be used say in financial applications. The full set of categories can be seen in the documentation link above.\n",
+    "`qiskit_algorithms` provides a number of [algorithms](https://qiskit-community.github.io/qiskit-algorithms/apidocs/algorithms.html) grouped by category, according to the task they can perform. For instance `Minimum Eigensolvers` to find the smallest eigen value of an operator, for example ground state energy of a chemistry Hamiltonian or a solution to an optimization problem when expressed as an Ising Hamiltonian. There are `Time Evolvers` for the time evolution of quantum systems and `Amplitude Estimators` for value estimation that can be used say in financial applications. The full set of categories can be seen in the documentation link above.\n",
     "\n",
     "Algorithms are configurable, and part of the configuration will often be in the form of smaller building blocks. For instance `VQE`, the Variational Quantum Eigensolver, it takes a trial wavefunction, in the form of a `QuantumCircuit` and a classical optimizer among other things.\n",
     "\n",
@@ -121,7 +121,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now we can call the [compute_mininum_eigenvalue()](https://qiskit.org/ecosystem/algorithms/stubs/qiskit_algorithms.VQE.html#qiskit_algorithms.VQE.compute_minimum_eigenvalue) method. The latter is the interface of choice for the application modules, such as Nature and Optimization, in order that they can work interchangeably with any algorithm within the specific category."
+    "Now we can call the [compute_mininum_eigenvalue()](https://qiskit-community.github.io/qiskit-algorithms/stubs/qiskit_algorithms.VQE.html#qiskit_algorithms.VQE.compute_minimum_eigenvalue) method. The latter is the interface of choice for the application modules, such as Nature and Optimization, in order that they can work interchangeably with any algorithm within the specific category."
    ]
   },
   {

--- a/docs/tutorials/02_vqe_advanced_options.ipynb
+++ b/docs/tutorials/02_vqe_advanced_options.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Advanced VQE Options\n",
     "\n",
-    "In the first algorithms tutorial, you learned how to set up a basic [VQE](https://qiskit.org/ecosystem/algorithms/stubs/qiskit_algorithms.VQE.html) algorithm. Now, you will see how to provide more advanced configuration parameters to explore the full range of the variational algorithms provided in this library: [VQE](https://qiskit.org/ecosystem/algorithms/stubs/qiskit_algorithms.VQE.html), [QAOA](https://qiskit.org/ecosystem/algorithms/stubs/qiskit_algorithms.QAOA.html) and [VQD](https://qiskit.org/ecosystem/algorithms/stubs/qiskit_algorithms.VQD.html) among others. In particular, this tutorial will cover how to set up a `callback` to monitor convergence and the use of custom `initial point`s and `gradient`s."
+    "In the first algorithms tutorial, you learned how to set up a basic [VQE](https://qiskit-community.github.io/qiskit-algorithms/stubs/qiskit_algorithms.VQE.html) algorithm. Now, you will see how to provide more advanced configuration parameters to explore the full range of the variational algorithms provided in this library: [VQE](https://qiskit-community.github.io/qiskit-algorithms/stubs/qiskit_algorithms.VQE.html), [QAOA](https://qiskit-community.github.io/qiskit-algorithms/stubs/qiskit_algorithms.QAOA.html) and [VQD](https://qiskit-community.github.io/qiskit-algorithms/stubs/qiskit_algorithms.VQD.html) among others. In particular, this tutorial will cover how to set up a `callback` to monitor convergence and the use of custom `initial point`s and `gradient`s."
    ]
   },
   {
@@ -33,7 +33,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "First, you need a qubit operator for VQE. For this example, you can use the same operator as used in the algorithms introduction, which was originally computed by [Qiskit Nature](https://qiskit.org/ecosystem/nature/) for an H2 molecule."
+    "First, you need a qubit operator for VQE. For this example, you can use the same operator as used in the algorithms introduction, which was originally computed by [Qiskit Nature](https://qiskit-community.github.io/qiskit-nature/) for an H2 molecule."
    ]
   },
   {
@@ -177,7 +177,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Finally, since the above problem is still easily tractable classically, you can use [NumPyMinimumEigensolver](https://qiskit.org/ecosystem/algorithms/stubs/qiskit_algorithms.NumPyMinimumEigensolver.html) to compute a reference value for the solution."
+    "Finally, since the above problem is still easily tractable classically, you can use [NumPyMinimumEigensolver](https://qiskit-community.github.io/qiskit-algorithms/stubs/qiskit_algorithms.NumPyMinimumEigensolver.html) to compute a reference value for the solution."
    ]
   },
   {
@@ -246,7 +246,7 @@
    "source": [
     "## Gradients\n",
     "\n",
-    "In the variational algorithms, if the provided optimizer uses a gradient-based technique, the default gradient method will be finite differences. However, these classes include an option to pass custom gradients via the `gradient` parameter, which can be any of the provided methods within the [gradient](https://qiskit.org/ecosystem/algorithms/stubs/qiskit_algorithms.gradients.html) framework, which fully supports the use of primitives. This section shows how to use custom gradients in the VQE workflow.\n",
+    "In the variational algorithms, if the provided optimizer uses a gradient-based technique, the default gradient method will be finite differences. However, these classes include an option to pass custom gradients via the `gradient` parameter, which can be any of the provided methods within the [gradient](https://qiskit-community.github.io/qiskit-algorithms/stubs/qiskit_algorithms.gradients.html) framework, which fully supports the use of primitives. This section shows how to use custom gradients in the VQE workflow.\n",
     "\n",
     "The first step is to initialize both the corresponding primitive and primitive gradient:"
    ]
@@ -267,7 +267,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now, you can inspect an SLSQP run using the [FiniteDiffEstimatorGradient](https://qiskit.org/ecosystem/algorithms/stubs/qiskit_algorithms.gradients.FiniteDiffEstimatorGradient.html) from above:"
+    "Now, you can inspect an SLSQP run using the [FiniteDiffEstimatorGradient](https://qiskit-community.github.io/qiskit-algorithms/stubs/qiskit_algorithms.gradients.FiniteDiffEstimatorGradient.html) from above:"
    ]
   },
   {

--- a/docs/tutorials/04_vqd.ipynb
+++ b/docs/tutorials/04_vqd.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Variational Quantum Deflation (VQD) Algorithm\n",
     "\n",
-    "This notebook demonstrates how to use our implementation of the [Variational Quantum Deflation (VQD)](https://qiskit.org/ecosystem/algorithms/stubs/qiskit_algorithms.VQD.html) algorithm for computing higher energy states of a Hamiltonian, as introduced in this [reference paper](https://arxiv.org/abs/1805.08138)."
+    "This notebook demonstrates how to use our implementation of the [Variational Quantum Deflation (VQD)](https://qiskit-community.github.io/qiskit-algorithms/stubs/qiskit_algorithms.VQD.html) algorithm for computing higher energy states of a Hamiltonian, as introduced in this [reference paper](https://arxiv.org/abs/1805.08138)."
    ]
   },
   {

--- a/docs/tutorials/05_qaoa.ipynb
+++ b/docs/tutorials/05_qaoa.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Quantum Approximate Optimization Algorithm\n",
     "\n",
-    "This notebook demonstrates the implementation of the Quantum Approximate Optimization Algorithm ([QAOA](https://qiskit.org/ecosystem/algorithms/stubs/qiskit_algorithms.QAOA.html)) for a graph partitioning problem (finding the maximum cut), and compares it to a solution using the brute-force approach."
+    "This notebook demonstrates the implementation of the Quantum Approximate Optimization Algorithm ([QAOA](https://qiskit-community.github.io/qiskit-algorithms/stubs/qiskit_algorithms.QAOA.html)) for a graph partitioning problem (finding the maximum cut), and compares it to a solution using the brute-force approach."
    ]
   },
   {

--- a/docs/tutorials/07_grover_examples.ipynb
+++ b/docs/tutorials/07_grover_examples.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Grover's algorithm examples\n",
     "\n",
-    "This notebook has examples demonstrating how to use the Qiskit Algorithms [Grover](https://qiskit.org/ecosystem/algorithms/stubs/qiskit_algorithms.Grover.html) search algorithm, with different oracles."
+    "This notebook has examples demonstrating how to use the Qiskit Algorithms [Grover](https://qiskit-community.github.io/qiskit-algorithms/stubs/qiskit_algorithms.Grover.html) search algorithm, with different oracles."
    ]
   },
   {

--- a/docs/tutorials/10_pvqd.ipynb
+++ b/docs/tutorials/10_pvqd.ipynb
@@ -16,7 +16,7 @@
     "\n",
     "where $e^{-i\\Delta_t H}$ is calculated with a Trotter expansion (using e.g. the [PauliEvolutionGate](https://qiskit.org/documentation/stubs/qiskit.circuit.library.PauliEvolutionGate.html) in Qiskit!).\n",
     "\n",
-    "The following tutorial explores the p-VQD algorithm, which is available as the [PVQD](https://qiskit.org/ecosystem/algorithms/stubs/qiskit_algorithms.PVQD.html) class. For details on the algorithm, see the original paper: [Barison et al. Quantum 5, 512 (2021)](https://quantum-journal.org/papers/q-2021-07-28-512/#)."
+    "The following tutorial explores the p-VQD algorithm, which is available as the [PVQD](https://qiskit-community.github.io/qiskit-algorithms/stubs/qiskit_algorithms.PVQD.html) class. For details on the algorithm, see the original paper: [Barison et al. Quantum 5, 512 (2021)](https://quantum-journal.org/papers/q-2021-07-28-512/#)."
    ]
   },
   {

--- a/docs/tutorials/11_VarQTE.ipynb
+++ b/docs/tutorials/11_VarQTE.ipynb
@@ -66,7 +66,7 @@
     "id": "WG-18slyLnVM"
    },
    "source": [
-    "In this tutorial, we will use two classes that extend `VarQTE`, `VarQITE` ([Variational Quantum Imaginary Time Evolution](https://qiskit.org/ecosystem/algorithms/stubs/qiskit_algorithms.VarQITE.html#qiskit_algorithms.VarQITE)) and `VarQRTE` ([Variational Quantum Real Time Evolution](https://qiskit.org/ecosystem/algorithms/stubs/qiskit_algorithms.VarQRTE.html)) for time evolution.\n",
+    "In this tutorial, we will use two classes that extend `VarQTE`, `VarQITE` ([Variational Quantum Imaginary Time Evolution](https://qiskit-community.github.io/qiskit-algorithms/stubs/qiskit_algorithms.VarQITE.html#qiskit_algorithms.VarQITE)) and `VarQRTE` ([Variational Quantum Real Time Evolution](https://qiskit-community.github.io/qiskit-algorithms/stubs/qiskit_algorithms.VarQRTE.html)) for time evolution.\n",
     "We can use a simple Ising model on a spin chain to illustrate this. Let us consider the following Hamiltonian:\n",
     "\n",
     "$$H = -J\\sum_{i=0}^{L-2}Z_{i}Z_{i+1} - h\\sum_{i=0}^{L-1}X_i$$\n",


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Updates links away from qiskit.org to the new locations for the docs

Fixes #135

#124 : I update all links but Aer for #124 as Aer is not yet done. This amounts to a couple of links in each of the 01 and 03 tutorials that will need to wait on relocated docs for Aer.

### Details and comments

Now that all the applications and the algorithms docs are deployed on github pages this updates the intersphinx links, in conf.py, and also urls that are coded directly in other places such as the readme and tutorials.

Note that the current theme is still emitting a link to qiskit.org/ecosystem, but that will get redirected for now until such time as Qiskit/qiskit_sphinx_theme#588 is resolved and new docs are generated with such an updated theme and re-deployed.

