### PR TITLE
Fix bounds parsing in Scipy optimizers and warn when unsupported

### DIFF
--- a/qiskit_algorithms/exceptions.py
+++ b/qiskit_algorithms/exceptions.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2017, 2023.
+# (C) Copyright IBM 2017, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -10,12 +10,30 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""Exception for errors raised by Algorithms module."""
+"""Exception and warnings for errors raised by Algorithms module."""
 
 from qiskit.exceptions import QiskitError
+import warnings
 
 
 class AlgorithmError(QiskitError):
     """For Algorithm specific errors."""
 
+    pass
+
+class QiskitAlgorithmsWarning(UserWarning):
+    """Base class for warnings raised by Qiskit Algorithms."""
+
+    def __init__(self, *message):
+        """Set the error message."""
+        super().__init__(" ".join(message))
+        self.message = " ".join(message)
+
+    def __str__(self):
+        """Return the message."""
+        return repr(self.message)
+    
+class QiskitAlgorithmsOptimizersWarning(QiskitAlgorithmsWarning):
+    """For Algorithm specific warnings."""
+    
     pass

--- a/qiskit_algorithms/optimizers/scipy_optimizer.py
+++ b/qiskit_algorithms/optimizers/scipy_optimizer.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2018, 2023.
+# (C) Copyright IBM 2018, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_algorithms/optimizers/scipy_optimizer.py
+++ b/qiskit_algorithms/optimizers/scipy_optimizer.py
@@ -145,6 +145,15 @@ class SciPyOptimizer(Optimizer):
             swapped_deprecated_args = True
             self._options["maxfun"] = self._options.pop("maxiter")
 
+        # Avoid clashing bounds defined in kwargs or _options
+        if 'bounds' in self._kwargs and not self.is_bounds_ignored:
+            bounds = self._kwargs['bounds']
+            del self._kwargs['bounds']
+
+        if 'bounds' in self._options and not self.is_bounds_ignored:
+            bounds = self._options['bounds']
+            del self._options['bounds']
+
         raw_result = minimize(
             fun=fun,
             x0=x0,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fixes the parsing of bounds to the Scipy optimizers, which previously raised the error below.
```
TypeError: scipy.optimize._minimize.minimize() got multiple values for keyword argument 'bounds'
```
The present PR fixes this behaviour documented in https://github.com/qiskit-community/qiskit-machine-learning/issues/570 and further discussed in https://github.com/qiskit-community/qiskit-algorithms/issues/57.

### Details and comments
This PR contains two updates. The first one gathers the bounds from `_options` or `_kwargs` if present, then copies them ont `bounds`, finally it deletes the key in the dictionaries, avoiding clashes in the https://github.com/edoaltamura/qiskit-algorithms/blob/77abbcbbeedba111cfde75df0cfea2940c9790dc/qiskit_algorithms/optimizers/scipy_optimizer.py#L165. The changes are below:
https://github.com/edoaltamura/qiskit-algorithms/blob/77abbcbbeedba111cfde75df0cfea2940c9790dc/qiskit_algorithms/optimizers/scipy_optimizer.py#L121-L127

The second update returns a warning when trying to assign a non-None bound value with an optimizer method that doesn't support it. The class `QiskitAlgorithmsOptimizersWarning` is defined in:
https://github.com/edoaltamura/qiskit-algorithms/blob/77abbcbbeedba111cfde75df0cfea2940c9790dc/qiskit_algorithms/exceptions.py#L24

For the bounds parsing, the derived class `QiskitAlgorithmsWarning` is defined and used:
https://github.com/edoaltamura/qiskit-algorithms/blob/77abbcbbeedba111cfde75df0cfea2940c9790dc/qiskit_algorithms/exceptions.py#L36

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.