### PR TITLE
Revert Python 3.12.0 specific usage

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -111,16 +111,16 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.8, 3.9, '3.10', 3.11, 3.12.0]
+        python-version: [3.8, 3.9, '3.10', 3.11, 3.12]
         include:
           - os: macos-latest
             python-version: 3.8
           - os: macos-latest
-            python-version: 3.12.0
+            python-version: 3.12
           - os: windows-latest
             python-version: 3.8
           - os: windows-latest
-            python-version: 3.12.0
+            python-version: 3.12
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -172,7 +172,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.8, 3.12.0]
+        python-version: [3.8, 3.12]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -278,7 +278,7 @@ jobs:
           path: /tmp/u311
       - uses: actions/download-artifact@v4
         with:
-          name: ubuntu-latest-3.12.0
+          name: ubuntu-latest-3.12
           path: /tmp/u312
       - uses: actions/download-artifact@v4
         with:
@@ -286,7 +286,7 @@ jobs:
           path: /tmp/m38
       - uses: actions/download-artifact@v4
         with:
-          name: macos-latest-3.12.0
+          name: macos-latest-3.12
           path: /tmp/m312
       - uses: actions/download-artifact@v4
         with:
@@ -294,7 +294,7 @@ jobs:
           path: /tmp/w38
       - uses: actions/download-artifact@v4
         with:
-          name: windows-latest-3.12.0
+          name: windows-latest-3.12
           path: /tmp/w312
       - name: Install Dependencies
         run: pip install -U coverage coveralls diff-cover


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Closes #113

It seems that the breaking change that caused test failure in 3.12.1, that had us pin to 3.12.0, has been reverted in 3.12.2. While the testtools has been fixed to accommodate that change, it has not yet had a release with the update in it, but given the change in Python has been reverted its no longer needed presently.

### Details and comments


