### PR TITLE
Add qiskit-neko integration tests

### DIFF
--- a/.github/workflows/neko.yaml
+++ b/.github/workflows/neko.yaml
@@ -8,17 +8,9 @@ concurrency:
   cancel-in-progress: true
 jobs:
   neko-nature:
-    name: Qiskit Neko Integration Tests - nature
+    name: Qiskit Neko Integration Tests
     runs-on: ubuntu-latest
     steps:
       - uses: Qiskit/qiskit-neko@main
         with:
-          test_selection: nature
-
-  neko-nature:
-    name: Qiskit Neko Integration Tests - primitives
-    runs-on: ubuntu-latest
-    steps:
-      - uses: Qiskit/qiskit-neko@main
-        with:
-          test_selection: primitives
+          test_selection: algorithms


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Since https://github.com/Qiskit/qiskit-neko/pull/34, the `qiskit-neko` nature and primitives tests use `qiskit_algorithms`.

This PR adds a new CI job to run the neko integration tests to (double) check that a proposed PR does not regress compatibility on an API or an integration point with another qiskit project and ensure that algorithms doesn't break CI for another project using neko.

### Details and comments
Gap discovered in https://github.com/Qiskit/qiskit-neko/pull/41.

~I've added two jobs, one for the nature tests and one for the primitives tests because I didn't find a way to squeeze both options into one job. Feel free to suggest how to do it if you have a better alternative.~ --> The better alternative is using the new component added in https://github.com/Qiskit/qiskit-neko/pull/43.

