### PR TITLE
 Change source code links to go to GitHub

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -230,8 +230,7 @@ def linkcode_resolve(domain, info):
     if full_file_name is None:
         return None
     try:
-        relative_file_name = Path(full_file_name).resolve().relative_to(REPO_ROOT)
-        file_name = re.sub(r"\.tox\/.+\/site-packages\/", "", str(relative_file_name))
+        file_name = Path(full_file_name).resolve().relative_to(REPO_ROOT)
     except ValueError:
         return None
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -230,10 +230,8 @@ def linkcode_resolve(domain, info):
     if full_file_name is None:
         return None
     try:
-        relative_file_name = Path(full_file_name).resolve().relative_to(REPO_ROOT)
-        file_name = re.sub(r"\.tox\/.+\/site-packages\/",
-                           "",
-                           str(relative_file_name))
+        relative_file_name = (Path(full_file_name).resolve().relative_to(REPO_ROOT))
+        file_name = re.sub(r"\.tox\/.+\/site-packages\/", "", str(relative_file_name))
     except ValueError:
         return None
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -242,5 +242,5 @@ def linkcode_resolve(domain, info):
         ending_lineno = lineno + len(source) - 1
         linespec = f"#L{lineno}-L{ending_lineno}"
 
-    repo_name = "Qiskit/qiskit/" if "qiskit/" in file_name else "qiskit-community/qiskit-algorithms"
+    repo_name = "Qiskit/qiskit/" if "qiskit/" in str(file_name) else "qiskit-community/qiskit-algorithms"
     return f"https://github.com/{repo_name}/tree/{GITHUB_BRANCH}/{file_name}{linespec}"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -172,6 +172,7 @@ doctest_test_doctest_blocks = ""
 # Source code links
 # ----------------------------------------------------------------------------------
 
+
 def determine_github_branch() -> str:
     """Determine the GitHub branch name to use for source code links.
 
@@ -192,11 +193,7 @@ def determine_github_branch() -> str:
     # Check if the ref_name is a tag like `1.0.0` or `1.0.0rc1`. If so, we need
     # to transform it to a Git branch like `stable/1.0`.
     version_without_patch = re.match(r"(\d+\.\d+)", ref_name)
-    return (
-        f"stable/{version_without_patch.group()}"
-        if version_without_patch
-        else ref_name
-    )
+    return f"stable/{version_without_patch.group()}" if version_without_patch else ref_name
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -230,7 +227,7 @@ def linkcode_resolve(domain, info):
     if full_file_name is None:
         return None
     try:
-        relative_file_name = (Path(full_file_name).resolve().relative_to(REPO_ROOT))
+        relative_file_name = Path(full_file_name).resolve().relative_to(REPO_ROOT)
         file_name = re.sub(r"\.tox\/.+\/site-packages\/", "", str(relative_file_name))
     except ValueError:
         return None
@@ -243,6 +240,7 @@ def linkcode_resolve(domain, info):
         ending_lineno = lineno + len(source) - 1
         linespec = f"#L{lineno}-L{ending_lineno}"
 
-    repo_name = "Qiskit/qiskit/" if "qiskit/" in str(file_name) else \
-        "qiskit-community/qiskit-algorithms"
+    repo_name = (
+        "Qiskit/qiskit/" if "qiskit/" in str(file_name) else "qiskit-community/qiskit-algorithms"
+    )
     return f"https://github.com/{repo_name}/tree/{GITHUB_BRANCH}/{file_name}{linespec}"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -231,7 +231,9 @@ def linkcode_resolve(domain, info):
         return None
     try:
         relative_file_name = Path(full_file_name).resolve().relative_to(REPO_ROOT)
-        file_name = re.sub(r"\.tox\/.+\/site-packages\/", "", str(relative_file_name))
+        file_name = re.sub(r"\.tox\/.+\/site-packages\/",
+                           "",
+                           str(relative_file_name))
     except ValueError:
         return None
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -230,7 +230,8 @@ def linkcode_resolve(domain, info):
     if full_file_name is None:
         return None
     try:
-        file_name = Path(full_file_name).resolve().relative_to(REPO_ROOT)
+        relative_file_name = Path(full_file_name).resolve().relative_to(REPO_ROOT)
+        file_name = re.sub(r"\.tox\/.+\/site-packages\/", "", str(relative_file_name))
     except ValueError:
         return None
 
@@ -242,5 +243,6 @@ def linkcode_resolve(domain, info):
         ending_lineno = lineno + len(source) - 1
         linespec = f"#L{lineno}-L{ending_lineno}"
 
-    repo_name = "Qiskit/qiskit/" if "qiskit/" in str(file_name) else "qiskit-community/qiskit-algorithms"
+    repo_name = "Qiskit/qiskit/" if "qiskit/" in str(file_name) else \
+        "qiskit-community/qiskit-algorithms"
     return f"https://github.com/{repo_name}/tree/{GITHUB_BRANCH}/{file_name}{linespec}"


### PR DESCRIPTION
### Summary
This would switch out the `sphinx.ext.viewcode` extension for the `sphinx.ext.linkcode` extension which allows source links in the API documentation to be linked to the specific lines of code in GitHub, instead of the sphinx-generated file. This was tested successfully in https://github.com/Qiskit/qiskit_sphinx_theme/pull/589 and we have now implemented it in the qiskit, runtime, provider, and qiskit-aer repos.

Example links generated in this PR build:

a class definition https://github.com/qiskit-community/qiskit-algorithms/blob/main/qiskit_algorithms/eigensolvers/eigensolver.py#L27-L67
a method https://github.com/qiskit-community/qiskit-algorithms/blob/main/qiskit_algorithms/amplitude_estimators/amplitude_estimator.py#L26-L34

### Details and comments
Since some references in the API documentation actually refer to methods from the inherited qiskit classes, it was necessary to add a check at the end to change the base url if the method was from the qiskit class and link to the qiskit repo.


