### PR TITLE
Fix power() in subclass test for QuantumCircuit change

### DIFF
--- a/qiskit_algorithms/gradients/reverse/derive_circuit.py
+++ b/qiskit_algorithms/gradients/reverse/derive_circuit.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2023.
+# (C) Copyright IBM 2022, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_algorithms/gradients/reverse/derive_circuit.py
+++ b/qiskit_algorithms/gradients/reverse/derive_circuit.py
@@ -148,7 +148,7 @@ def derive_circuit(
     gradient = []
     for product_rule_term in itertools.product(*summands):
         summand_circuit = QuantumCircuit(*circuit.qregs)
-        c = 1
+        c = complex(1)
         for i, term in enumerate(product_rule_term):
             c *= term[0]
             summand_circuit.data.append([term[1], *op_context[i]])

--- a/test/test_amplitude_estimators.py
+++ b/test/test_amplitude_estimators.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2018, 2023.
+# (C) Copyright IBM 2018, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -47,7 +47,9 @@ class BernoulliGrover(QuantumCircuit):
         self.angle = 2 * np.arcsin(np.sqrt(probability))
         self.ry(2 * self.angle, 0)
 
-    def power(self, power, matrix_power=False):
+    # Disable for pylint needed for Qiskit < 1.1.0 where annotated does not exist
+    # pylint: disable=unused-argument
+    def power(self, power, matrix_power=False, annotated: bool = False):
         if matrix_power:
             return super().power(power, True)
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
 
Qiskit tests against main have been failing lint recently due to power() in QuantumCircuit gaining an extra parameter. With 1.1 going live shortly, where it will become the stable version tested against here, this amends the test to work and pass lint for existing versions of Qiskit e.g 0.46 and 1.0 as well as 1.1


### Details and comments

As it's just a test case fix there is no reno needed. I marked this for backporting to stable as it will affect any builds done there once 1.1 releases.
