### PR TITLE
Fix lint errors for latest pylint

### DIFF
--- a/.pylintdict
+++ b/.pylintdict
@@ -77,6 +77,7 @@ eigensolver
 eigensolvers
 eigenstate
 eigenstates
+elif
 entangler
 enum
 eps

--- a/qiskit_algorithms/amplitude_estimators/fae.py
+++ b/qiskit_algorithms/amplitude_estimators/fae.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2017, 2023.
+# (C) Copyright IBM 2017, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -198,6 +198,12 @@ class FasterAmplitudeEstimation(AmplitudeEstimator):
 
         def cos_estimate(power, shots):
             return self._cos_estimate(problem, power, shots)
+
+        # v is first defined in an if below and referenced after in the else where static analysis
+        # e.g. lint, may determine that v might not be defined before used. So this defines it here
+        # to avoid lint error. Note the code cannot exit the first stage path until its defined so
+        # this value here will never get used in practice.
+        v = 0
 
         for j in range(1, self._maxiter + 1):
             num_steps += 1

--- a/qiskit_algorithms/eigensolvers/vqd.py
+++ b/qiskit_algorithms/eigensolvers/vqd.py
@@ -248,6 +248,13 @@ class VQD(VariationalAlgorithm, Eigensolver):
         # the same parameters to the ansatz if we do multiple steps
         prev_states = []
 
+        # These two variables are defined inside if statements and static analysis, e.g. lint can
+        # see this as a potential error of them not being defined before use. Following the logic
+        # they do end up being defined before use so the setting of these here, these values would
+        # not be used in practice.
+        initial_point = np.asarray([])
+        initial_points = np.asarray([])
+
         num_initial_points = 0
         if self.initial_point is not None:
             initial_points = np.reshape(self.initial_point, (-1, self.ansatz.num_parameters))

--- a/qiskit_algorithms/gradients/finite_diff/finite_diff_estimator_gradient.py
+++ b/qiskit_algorithms/gradients/finite_diff/finite_diff_estimator_gradient.py
@@ -135,7 +135,7 @@ class FiniteDiffEstimatorGradient(BaseEstimatorGradient):
             # otherwise lint errors out. I left the if block as it has been coded though
             # as the values are checked in the constructor I could have made the last elif
             # a simple else instead of defining this here.
-            gradient = 0
+            gradient = None
             if self._method == "central":
                 result = results.values[partial_sum_n : partial_sum_n + n]
                 gradient = (result[: n // 2] - result[n // 2 :]) / (2 * self._epsilon)

--- a/qiskit_algorithms/gradients/finite_diff/finite_diff_estimator_gradient.py
+++ b/qiskit_algorithms/gradients/finite_diff/finite_diff_estimator_gradient.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2023.
+# (C) Copyright IBM 2022, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -131,6 +131,11 @@ class FiniteDiffEstimatorGradient(BaseEstimatorGradient):
         gradients = []
         partial_sum_n = 0
         for n in all_n:
+            # Ensure gradient is always defined for the append below after the if block
+            # otherwise lint errors out. I left the if block as it has been coded though
+            # as the values are checked in the constructor I could have made the last elif
+            # a simple else instead of defining this here.
+            gradient = 0
             if self._method == "central":
                 result = results.values[partial_sum_n : partial_sum_n + n]
                 gradient = (result[: n // 2] - result[n // 2 :]) / (2 * self._epsilon)

--- a/qiskit_algorithms/time_evolvers/trotterization/trotter_qrte.py
+++ b/qiskit_algorithms/time_evolvers/trotterization/trotter_qrte.py
@@ -214,6 +214,9 @@ class TrotterQRTE(RealTimeEvolver):
         else:
             observables = None
 
+        # Empty define to avoid possibly undefined lint error later here
+        single_step_evolution_gate = None
+
         if t_param is None:
             # the evolution gate
             single_step_evolution_gate = PauliEvolutionGate(

--- a/test/test_grover.py
+++ b/test/test_grover.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2018, 2023.
+# (C) Copyright IBM 2018, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -312,6 +312,8 @@ class TestGrover(QiskitAlgorithmsTestCase):
                 growth_rate=growth_rate,
                 sample_from_iterations=sample_from_iterations,
             )
+        else:
+            raise RuntimeError("Unexpected `use_sampler` value {use_sampler}")
         return grover
 
 

--- a/test/time_evolvers/test_trotter_qrte.py
+++ b/test/time_evolvers/test_trotter_qrte.py
@@ -262,6 +262,7 @@ class TestTrotterQRTE(QiskitAlgorithmsTestCase):
         observables = [obs.to_matrix() for obs in observables]
 
         psi = Statevector(init_state).data
+        ops = []  # Define to avoid possibly undefined error later on the line where it's used
         if t_param is None:
             ops = [Pauli(op).to_matrix() * np.real(coeff) for op, coeff in operator.to_list()]
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes to various possibly undefined errors from newest lint

```
************* Module qiskit_algorithms.gradients.finite_diff.finite_diff_estimator_gradient
qiskit_algorithms/gradients/finite_diff/finite_diff_estimator_gradient.py:144:29: E0606: Possibly using variable 'gradient' before assignment (possibly-used-before-assignment)
************* Module qiskit_algorithms.amplitude_estimators.fae
qiskit_algorithms/amplitude_estimators/fae.py:217:36: E0606: Possibly using variable 'v' before assignment (possibly-used-before-assignment)
************* Module qiskit_algorithms.eigensolvers.vqd
qiskit_algorithms/eigensolvers/vqd.py:286:23: E0606: Possibly using variable 'initial_point' before assignment (possibly-used-before-assignment)
************* Module qiskit_algorithms.time_evolvers.trotterization.trotter_qrte
qiskit_algorithms/time_evolvers/trotterization/trotter_qrte.py:234:33: E0606: Possibly using variable 'single_step_evolution_gate' before assignment (possibly-used-before-assignment)
************* Module test.test_grover
test/test_grover.py:315:15: E0606: Possibly using variable 'grover' before assignment (possibly-used-before-assignment)
************* Module test.time_evolvers.test_trotter_qrte
test/time_evolvers/test_trotter_qrte.py:276:22: E0606: Possibly using variable 'ops' before assignment (possibly-used-before-assignment)
```


### Details and comments


