### PR TITLE
Scipy 1.14 compatibility fix

### DIFF
--- a/.pylintdict
+++ b/.pylintdict
@@ -52,6 +52,7 @@ configs
 confint
 córcoles
 crs
+csr
 currentmodule
 customizable
 cvar

--- a/qiskit_algorithms/eigensolvers/numpy_eigensolver.py
+++ b/qiskit_algorithms/eigensolvers/numpy_eigensolver.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2023.
+# (C) Copyright IBM 2022, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -152,7 +152,7 @@ class NumPyEigensolver(Eigensolver):
 
     @staticmethod
     def _solve_sparse(op_matrix: scisparse.csr_matrix, k: int) -> tuple[np.ndarray, np.ndarray]:
-        if (op_matrix != op_matrix.H).nnz == 0:
+        if (op_matrix != op_matrix.getH()).nnz == 0:
             # Operator is Hermitian
             return scisparse.linalg.eigsh(op_matrix, k=k, which="SA")
         else:

--- a/releasenotes/notes/numpy_2.0_fix-c29681db4874eee8.yaml
+++ b/releasenotes/notes/numpy_2.0_fix-c29681db4874eee8.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Compatibility fix for numpy 2.0 version. csr_matrix.H had been deprecated
+    and was removed in 2.0. The :class:`.NumPyEigensolver` algorithm, which
+    had been using that, has been updated to use an alternative.

--- a/releasenotes/notes/numpy_2.0_fix-c29681db4874eee8.yaml
+++ b/releasenotes/notes/numpy_2.0_fix-c29681db4874eee8.yaml
@@ -1,6 +1,6 @@
 ---
 fixes:
   - |
-    Compatibility fix for numpy 2.0 version. csr_matrix.H had been deprecated
-    and was removed in 2.0. The :class:`.NumPyEigensolver` algorithm, which
+    Compatibility fix for scipy 1.14 version. csr_matrix.H had been deprecated
+    and was removed. The :class:`.NumPyEigensolver` algorithm, which
     had been using that, has been updated to use an alternative.


### PR DESCRIPTION
### Summary

Fixes #182

Scipy 1.14 compatibility fix

### Details and comments

Using .H from csr_matrix had been deprecated and has now been removed in scipy 1.14. This changes NumPyEigensolver, to use an alternative (and works with the prior scipy). This also ends up fixing CI which has been failing in nightly builds recently.
