### PR TITLE
SciPy 1.14 removed `H` for sparse arrays

### DIFF
--- a/qiskit_algorithms/eigensolvers/numpy_eigensolver.py
+++ b/qiskit_algorithms/eigensolvers/numpy_eigensolver.py
@@ -149,7 +149,7 @@ class NumPyEigensolver(Eigensolver):
 
     @staticmethod
     def _solve_sparse(op_matrix: scisparse.csr_matrix, k: int) -> tuple[np.ndarray, np.ndarray]:
-        if (op_matrix != op_matrix.H).nnz == 0:
+        if (op_matrix != op_matrix.T.conj()).nnz == 0:
             # Operator is Hermitian
             return scisparse.linalg.eigsh(op_matrix, k=k, which="SA")
         else:

--- a/releasenotes/notes/scipy_1.14-fa37364551877196.yaml
+++ b/releasenotes/notes/scipy_1.14-fa37364551877196.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Scipy 1.14 removed `the ``H`` attribute <https://docs.scipy.org/doc/scipy-1.14.0/release/1.14.0-notes.html#expired-deprecations>
+    for sparse arrays, which it was used by :class:`.NumPyEigensolver`. It was replaced by ``T.conj()``.


### PR DESCRIPTION
Fixes #189 

With the release of SciPy 1.14 (released on Jun 14) the property `H` for sparse arrays was removed. This PR replace it with the recommended `T.conj()`.

Thanks @kevinsung for the fix suggestion and @twobombs to bring the attention to the problem during the Qiskit Community call.

The tests in `test.eigensolvers.test_numpy_eigensolver.TestNumPyEigensolver` also were not passing because of this issue and it was used for testing this fix.