### PR TITLE
Change test with Qiskit main to 3.9 for min version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -172,7 +172,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.8, 3.12]
+        python-version: [3.9, 3.12]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This changes CI so that the tests run against Qiskit main are now done on 3.9 as the minimum level (rather than 3.8). See also this issue, which this partially addresses

* #201

### Details and comments

This only changes the CI done against Qiskit main branch as this change is not yet in a released version. These tests on main do not cause any PR to not be mergable as the intent was just to have jobs, particularly in nightly runs, where things were tested again Qiskit main in case of any breaking changes etc we would have an idea early on and could take whatever appropriate action was deemed right to sort out any failure(s). In this case the change was known to be happening so I have simply just amended CI here accordingly for its tests against Qiskit main.
