### PR TITLE
Adding a convergence threshold to VQD to filter non-sensible values

### DIFF
--- a/docs/tutorials/04_vqd.ipynb
+++ b/docs/tutorials/04_vqd.ipynb
@@ -83,11 +83,11 @@
    ],
    "source": [
     "from qiskit.circuit.library import TwoLocal\n",
-    "from qiskit_algorithms.optimizers import SLSQP\n",
+    "from qiskit_algorithms.optimizers import COBYLA\n",
     "\n",
     "ansatz = TwoLocal(2, rotation_blocks=[\"ry\", \"rz\"], entanglement_blocks=\"cz\", reps=1)\n",
     "\n",
-    "optimizer = SLSQP()\n",
+    "optimizer = COBYLA()\n",
     "ansatz.decompose().draw(\"mpl\")"
    ]
   },
@@ -128,7 +128,7 @@
    "outputs": [],
    "source": [
     "k = 3\n",
-    "betas = [33, 33, 33]"
+    "betas = [3, 3, 3]"
    ]
   },
   {

--- a/docs/tutorials/04_vqd.ipynb
+++ b/docs/tutorials/04_vqd.ipynb
@@ -15,7 +15,7 @@
    "source": [
     "## Introduction\n",
     "\n",
-    "VQD is a quantum algorithm that uses a variational technique to find the *k* eigenvalues of the Hamiltonian *H* of a given system.\n",
+    "VQD is a quantum algorithm that uses a variational technique to find the *k* lowest eigenvalues of the Hamiltonian *H* of a given system.\n",
     "\n",
     "The algorithm computes excited state energies of generalized hamiltonians by optimizing over a modified cost function. Each successive eigenvalue is calculated iteratively by introducing an overlap term with all the previously computed eigenstates that must be minimized. This ensures that higher energy eigenstates are found."
    ]
@@ -360,7 +360,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.12.6"
   }
  },
  "nbformat": 4,

--- a/qiskit_algorithms/eigensolvers/vqd.py
+++ b/qiskit_algorithms/eigensolvers/vqd.py
@@ -352,7 +352,7 @@ class VQD(VariationalAlgorithm, Eigensolver):
                 ):
                     last_digit = step % 10
 
-                    if last_digit == 1:
+                    if last_digit == 1 and step % 100 != 11:
                         suffix = "st"
                     elif last_digit == 2:
                         suffix = "nd"
@@ -363,8 +363,8 @@ class VQD(VariationalAlgorithm, Eigensolver):
 
                     raise AlgorithmError(
                         f"Convergence threshold is set to {self.convergence_threshold} but an "
-                        f"average fidelity {average_fidelity:.5f} with the previous eigenstates"
-                        f"have been observed during the evaluation of the {step}{suffix} lowest"
+                        f"average fidelity of {average_fidelity:.5f} with the previous eigenstates"
+                        f"has been observed during the evaluation of the {step}{suffix} lowest"
                         f"eigenvalue."
                     )
                 logger.info(

--- a/qiskit_algorithms/eigensolvers/vqd.py
+++ b/qiskit_algorithms/eigensolvers/vqd.py
@@ -276,6 +276,8 @@ class VQD(VariationalAlgorithm, Eigensolver):
             )
 
         for step in range(1, self.k + 1):
+            current_optimal_point: dict[str, Any] = {"optimal_value": float("inf")}
+
             if num_initial_points > 1:
                 initial_point = validate_initial_point(initial_points[step - 1], self.ansatz)
 
@@ -283,7 +285,6 @@ class VQD(VariationalAlgorithm, Eigensolver):
                 prev_states.append(self.ansatz.assign_parameters(current_optimal_point["x"]))
 
             self._eval_count = 0
-            current_optimal_point = {"optimal_value": float("inf")}
             energy_evaluation = self._get_evaluate_energy(
                 step,
                 operator,
@@ -383,7 +384,7 @@ class VQD(VariationalAlgorithm, Eigensolver):
 
         return result
 
-    def _get_evaluate_energy(
+    def _get_evaluate_energy( # pylint: disable=too-many-positional-arguments
         self,
         step: int,
         operator: BaseOperator,

--- a/qiskit_algorithms/eigensolvers/vqd.py
+++ b/qiskit_algorithms/eigensolvers/vqd.py
@@ -283,7 +283,7 @@ class VQD(VariationalAlgorithm, Eigensolver):
                 prev_states.append(self.ansatz.assign_parameters(current_optimal_point["x"]))
 
             self._eval_count = 0
-            current_optimal_point = {"optimal_value": float('inf')}
+            current_optimal_point = {"optimal_value": float("inf")}
             energy_evaluation = self._get_evaluate_energy(
                 step,
                 operator,
@@ -322,7 +322,9 @@ class VQD(VariationalAlgorithm, Eigensolver):
 
             eval_time = time() - start_time
 
-            self._update_vqd_result(result, opt_result, eval_time, self.ansatz.copy(), current_optimal_point)
+            self._update_vqd_result(
+                result, opt_result, eval_time, self.ansatz.copy(), current_optimal_point
+            )
 
             if aux_operators is not None:
                 aux_value = estimate_observables(
@@ -341,7 +343,10 @@ class VQD(VariationalAlgorithm, Eigensolver):
             else:
                 average_fidelity = current_optimal_point["total_fidelity"][0] / (step - 1)
 
-                if self.convergence_threshold is not None and average_fidelity > self.convergence_threshold:
+                if (
+                    self.convergence_threshold is not None
+                    and average_fidelity > self.convergence_threshold
+                ):
                     last_digit = step % 10
 
                     if last_digit == 1:
@@ -355,8 +360,9 @@ class VQD(VariationalAlgorithm, Eigensolver):
 
                     raise AlgorithmError(
                         f"Convergence threshold is set to {self.convergence_threshold} but an "
-                        f"average fidelity {average_fidelity:.5f} with the previous eigenstates have been"
-                        f" observed during the evaluation of the {step}{suffix} lowest eigenvalue."
+                        f"average fidelity {average_fidelity:.5f} with the previous eigenstates"
+                        f"have been observed during the evaluation of the {step}{suffix} lowest"
+                        f"eigenvalue."
                     )
                 logger.info(
                     (
@@ -500,7 +506,9 @@ class VQD(VariationalAlgorithm, Eigensolver):
         result.optimal_parameters.append(
             dict(zip(ansatz.parameters, cast(np.ndarray, optimal_point["x"])))
         )
-        result.optimal_values = np.concatenate([result.optimal_values, [optimal_point["optimal_value"]]])
+        result.optimal_values = np.concatenate(
+            [result.optimal_values, [optimal_point["optimal_value"]]]
+        )
         result.cost_function_evals = np.concatenate([result.cost_function_evals, [opt_result.nfev]])
         result.optimizer_times = np.concatenate([result.optimizer_times, [eval_time]])
         result.eigenvalues.append(optimal_point["eigenvalue"] + 0j)  # type: ignore[attr-defined]

--- a/qiskit_algorithms/eigensolvers/vqd.py
+++ b/qiskit_algorithms/eigensolvers/vqd.py
@@ -275,8 +275,10 @@ class VQD(VariationalAlgorithm, Eigensolver):
                 self.initial_point, self.ansatz  # type: ignore[arg-type]
             )
 
+        current_optimal_point: dict[str, Any] = {"optimal_value": float("inf")}
+
         for step in range(1, self.k + 1):
-            current_optimal_point: dict[str, Any] = {"optimal_value": float("inf")}
+            current_optimal_point["optimal_value"] = float("inf")
 
             if num_initial_points > 1:
                 initial_point = validate_initial_point(initial_points[step - 1], self.ansatz)
@@ -384,7 +386,7 @@ class VQD(VariationalAlgorithm, Eigensolver):
 
         return result
 
-    def _get_evaluate_energy( # pylint: disable=too-many-positional-arguments
+    def _get_evaluate_energy(  # pylint: disable=too-many-positional-arguments
         self,
         step: int,
         operator: BaseOperator,

--- a/test/eigensolvers/test_vqd.py
+++ b/test/eigensolvers/test_vqd.py
@@ -105,7 +105,14 @@ class TestVQD(QiskitAlgorithmsTestCase):
 
     def test_full_spectrum(self):
         """Test obtaining all eigenvalues."""
-        vqd = VQD(self.estimator, self.fidelity, self.ryrz_wavefunction, optimizer=COBYLA(), k=4, betas=[3, 3, 3])
+        vqd = VQD(
+            self.estimator,
+            self.fidelity,
+            self.ryrz_wavefunction,
+            optimizer=COBYLA(),
+            k=4,
+            betas=[3, 3, 3],
+        )
         result = vqd.compute_eigenvalues(H2_SPARSE_PAULI)
         np.testing.assert_array_almost_equal(
             result.eigenvalues.real, self.h2_energy_excited, decimal=2
@@ -190,7 +197,7 @@ class TestVQD(QiskitAlgorithmsTestCase):
             self.assertTrue(all(isinstance(param, float) for param in params))
 
         ref_eval_count = [1, 2, 3, 1, 2, 3]
-        ref_mean = [-1.07, -1.45, -1.36,  1.24,  1.55,  1.07]
+        ref_mean = [-1.07, -1.45, -1.36, 1.24, 1.55, 1.07]
         # new ref_mean since the betas were changed
 
         ref_step = [1, 1, 1, 2, 2, 2]
@@ -440,6 +447,7 @@ class TestVQD(QiskitAlgorithmsTestCase):
         self.assertIsInstance(result.aux_operators_evaluated[0][3][1], dict)
 
     def test_convergence_threshold(self):
+        """Test the convergence threshold raises an error if and only if too high"""
         vqd = VQD(
             self.estimator,
             self.fidelity,

--- a/test/eigensolvers/test_vqd.py
+++ b/test/eigensolvers/test_vqd.py
@@ -59,8 +59,8 @@ class TestVQD(QiskitAlgorithmsTestCase):
 
         self.estimator = Estimator()
         self.estimator_shots = Estimator(options={"shots": 1024, "seed": self.seed})
-        self.fidelity = ComputeUncompute(Sampler())
-        self.betas = [50, 50]
+        self.fidelity = ComputeUncompute(Sampler(options={"shots": 100_000, "seed": self.seed}))
+        self.betas = [3]
 
     @data(H2_SPARSE_PAULI)
     def test_basic_operator(self, op):
@@ -105,7 +105,7 @@ class TestVQD(QiskitAlgorithmsTestCase):
 
     def test_full_spectrum(self):
         """Test obtaining all eigenvalues."""
-        vqd = VQD(self.estimator, self.fidelity, self.ryrz_wavefunction, optimizer=L_BFGS_B(), k=4)
+        vqd = VQD(self.estimator, self.fidelity, self.ryrz_wavefunction, optimizer=COBYLA(), k=4, betas=[3, 3, 3])
         result = vqd.compute_eigenvalues(H2_SPARSE_PAULI)
         np.testing.assert_array_almost_equal(
             result.eigenvalues.real, self.h2_energy_excited, decimal=2
@@ -190,9 +190,8 @@ class TestVQD(QiskitAlgorithmsTestCase):
             self.assertTrue(all(isinstance(param, float) for param in params))
 
         ref_eval_count = [1, 2, 3, 1, 2, 3]
-        ref_mean = [-1.07, -1.45, -1.37, 37.43, 48.55, 28.94]
-        # new ref_mean for statevector simulator. The old unit test was on qasm
-        # and the ref_mean values were slightly different.
+        ref_mean = [-1.07, -1.45, -1.36,  1.24,  1.55,  1.07]
+        # new ref_mean since the betas were changed
 
         ref_step = [1, 1, 1, 2, 2, 2]
 
@@ -208,7 +207,7 @@ class TestVQD(QiskitAlgorithmsTestCase):
             estimator=self.estimator,
             fidelity=self.fidelity,
             ansatz=RealAmplitudes(),
-            optimizer=SLSQP(),
+            optimizer=COBYLA(),
             k=2,
             betas=self.betas,
         )
@@ -216,7 +215,7 @@ class TestVQD(QiskitAlgorithmsTestCase):
         def run_check():
             result = vqd.compute_eigenvalues(operator=op)
             np.testing.assert_array_almost_equal(
-                result.eigenvalues.real, self.h2_energy_excited[:2], decimal=3
+                result.eigenvalues.real, self.h2_energy_excited[:2], decimal=2
             )
 
         run_check()
@@ -225,11 +224,11 @@ class TestVQD(QiskitAlgorithmsTestCase):
             run_check()
 
         with self.subTest("Optimizer replace"):
-            vqd.optimizer = L_BFGS_B()
+            vqd.optimizer = SPSA()
             run_check()
 
         with self.subTest("Batched optimizer replace"):
-            vqd.optimizer = SLSQP(maxiter=60, max_evals_grouped=10)
+            vqd.optimizer = COBYLA(maxiter=60, max_evals_grouped=10)
             run_check()
 
         with self.subTest("SPSA replace"):
@@ -243,7 +242,7 @@ class TestVQD(QiskitAlgorithmsTestCase):
     def test_optimizer_list(self, op):
         """Test sending an optimizer list"""
 
-        optimizers = [SLSQP(), L_BFGS_B()]
+        optimizers = [COBYLA(), SPSA()]
         initial_point_1 = [
             1.70256666,
             -5.34843975,
@@ -287,7 +286,7 @@ class TestVQD(QiskitAlgorithmsTestCase):
             estimator=self.estimator,
             fidelity=self.fidelity,
             ansatz=wavefunction,
-            optimizer=SLSQP(),
+            optimizer=COBYLA(),
             k=2,
             betas=self.betas,
         )
@@ -340,7 +339,7 @@ class TestVQD(QiskitAlgorithmsTestCase):
             estimator=self.estimator,
             fidelity=self.fidelity,
             ansatz=wavefunction,
-            optimizer=SLSQP(),
+            optimizer=COBYLA(),
             betas=self.betas,
         )
 
@@ -439,6 +438,27 @@ class TestVQD(QiskitAlgorithmsTestCase):
         self.assertIsInstance(result.aux_operators_evaluated[0][1][1], dict)
         self.assertIsInstance(result.aux_operators_evaluated[0][2][1], dict)
         self.assertIsInstance(result.aux_operators_evaluated[0][3][1], dict)
+
+    def test_convergence_threshold(self):
+        vqd = VQD(
+            self.estimator,
+            self.fidelity,
+            RealAmplitudes(),
+            SLSQP(),
+            k=2,
+            betas=self.betas,
+            convergence_threshold=1e-3,
+        )
+        with self.subTest("Failed convergence"):
+            with self.assertRaises(AlgorithmError):
+                vqd.compute_eigenvalues(operator=H2_SPARSE_PAULI)
+
+        with self.subTest("Convergence accepted"):
+            vqd.convergence_threshold = 1e-1
+            result = vqd.compute_eigenvalues(operator=H2_SPARSE_PAULI)
+            np.testing.assert_array_almost_equal(
+                result.eigenvalues.real, self.h2_energy_excited[:2], decimal=2
+            )
 
 
 if __name__ == "__main__":

--- a/test/eigensolvers/test_vqd.py
+++ b/test/eigensolvers/test_vqd.py
@@ -465,7 +465,7 @@ class TestVQD(QiskitAlgorithmsTestCase):
             vqd.convergence_threshold = 1e-1
             result = vqd.compute_eigenvalues(operator=H2_SPARSE_PAULI)
             np.testing.assert_array_almost_equal(
-                result.eigenvalues.real, self.h2_energy_excited[:2], decimal=2
+                result.eigenvalues.real, self.h2_energy_excited[:2], decimal=1
             )
 
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
As mentioned [here](https://github.com/qiskit-community/qiskit-algorithms/issues/136#issuecomment-2356561939), some optimizers don't work well with shots-based samplers. This leads to VQD returning sometimes absurd values, as shown [here](https://github.com/qiskit-community/qiskit-algorithms/issues/136#issuecomment-2356242004).

This Pull Request adds a `convergence_threshold` to `VQD` to test whether the optimization converged well.

It also paves the road for adapting VQD to V2 primitives.


### Details and comments
Changes that were made:
 - a `convergence_threshold` parameter now tests whether the average fidelity of the $k$-th eigenstate w.r.t. the previously found eigenstates is larger than this threshold, indicating that not only the eigenvalue returned is likely to be false, but the next iterations won't make sense either.
 - if the `convergence_threshold` test passes, `VQD` now returns $\left\langle\psi_k\middle|H\middle|\psi_k\right\rangle$ instead of $\left\langle\psi_k\middle|H\middle|\psi_k\right\rangle+\sum\limits_{i=1}^{k-1}\beta_i\left|\left\langle\psi_k\middle|\psi_i\right\rangle\right|^2$, which not only makes more sense, but also allows to get decent values even when using gradients-based optimizers such as `SLSQP`.
 - the tutorial has been updated to use `COBYLA` and a value of `betas` that are closer to real-world use cases.
 - the tests have been updated. In particular, the values of `betas` have been updated from 50 to 3. A too large value with shot noise made the optimizers focus solely on the fidelity part, forgetting about the energy part.

