### PR TITLE
Add Python 3.13 as supported

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -111,16 +111,16 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.9, '3.10', 3.11, 3.12]
+        python-version: [3.9, '3.10', 3.11, 3.12, 3.13]
         include:
           - os: macos-latest
             python-version: 3.9
           - os: macos-latest
-            python-version: 3.12
+            python-version: 3.13
           - os: windows-latest
             python-version: 3.9
           - os: windows-latest
-            python-version: 3.12
+            python-version: 3.13
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -172,7 +172,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.9, 3.12]
+        python-version: [3.9, 3.13]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -209,7 +209,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.9, 3.12]
+        python-version: [3.9, 3.13]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -279,26 +279,30 @@ jobs:
           path: /tmp/u312
       - uses: actions/download-artifact@v4
         with:
+          name: ubuntu-latest-3.13
+          path: /tmp/u313
+      - uses: actions/download-artifact@v4
+        with:
           name: macos-latest-3.9
           path: /tmp/m39
       - uses: actions/download-artifact@v4
         with:
-          name: macos-latest-3.12
-          path: /tmp/m312
+          name: macos-latest-3.13
+          path: /tmp/m313
       - uses: actions/download-artifact@v4
         with:
           name: windows-latest-3.9
           path: /tmp/w39
       - uses: actions/download-artifact@v4
         with:
-          name: windows-latest-3.12
-          path: /tmp/w312
+          name: windows-latest-3.13
+          path: /tmp/w313
       - name: Install Dependencies
         run: pip install -U coverage coveralls diff-cover
         shell: bash
       - name: Combined Deprecation Messages
         run: |
-          sort -f -u /tmp/u39/alg.dep /tmp/u310/alg.dep /tmp/u311/alg.dep /tmp/u312/alg.dep /tmp/m39/alg.dep /tmp/m312/alg.dep /tmp/w39/alg.dep /tmp/w312/alg.dep || true
+          sort -f -u /tmp/u39/alg.dep /tmp/u310/alg.dep /tmp/u311/alg.dep /tmp/u312/alg.dep /tmp/u313/alg.dep /tmp/m39/alg.dep /tmp/m313/alg.dep /tmp/w39/alg.dep /tmp/w313/alg.dep || true
         shell: bash
       - name: Coverage combine
         run: coverage3 combine /tmp/u39/alg.dat

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.black]
 line-length = 100
-target-version = ['py39', 'py310', 'py311']
+target-version = ['py39', 'py310', 'py311', 'py312', 'py313']
 
 [tool.pylint.main]
 extension-pkg-allow-list = [

--- a/qiskit_algorithms/optimizers/gradient_descent.py
+++ b/qiskit_algorithms/optimizers/gradient_descent.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2024.
+# (C) Copyright IBM 2021, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -41,6 +41,13 @@ class GradientDescentState(OptimizerState):
     next step) but it can also return  the current learning rate with ``learning_rate.current``.
 
     """
+
+    # See parent class for a comment on having a custom equals. I needed this
+    # too as it does not appear to use super by default and without this failed
+    # the exact same way. Note it does not include learning rate as that field
+    # is not included in the compare as pre the field decorator.
+    def __eq__(self, other: GradientDescentState):
+        return super().__eq__(other) and self.stepsize == other.stepsize
 
 
 class GradientDescent(SteppableOptimizer):

--- a/qiskit_algorithms/optimizers/steppable_optimizer.py
+++ b/qiskit_algorithms/optimizers/steppable_optimizer.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2023.
+# (C) Copyright IBM 2022, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -72,6 +72,23 @@ class OptimizerState:
     """Number of jacobian evaluations so far in the optimization."""
     nit: int | None
     """Number of optimization steps performed so far in the optimization."""
+
+    # Under Python 3.13 the auto-generated equal fails with a error around
+    # using numpy all or any. See https://github.com/qiskit-community/qiskit-algorithms/pull/225
+    # for further information. Hence this custom function was added.
+    def __eq__(self, other: OptimizerState):
+        return (
+            (
+                self.x == other.x
+                if isinstance(self.x, float)
+                else (self.x.shape == other.x.shape and (self.x == other.x).all())
+            )
+            and self.fun == other.fun
+            and self.jac == other.jac
+            and self.nfev == other.nfev
+            and self.njev == other.njev
+            and self.nit == other.nit
+        )
 
 
 class SteppableOptimizer(Optimizer):

--- a/releasenotes/notes/add_python_3_13_support-3de8e3dc2e9dbd57.yaml
+++ b/releasenotes/notes/add_python_3_13_support-3de8e3dc2e9dbd57.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Added Python 3.13 support.

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Topic :: Scientific/Engineering",
     ],
     keywords="qiskit sdk quantum algorithms",

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 # Sets this min.version because of differences with env_tmp_dir env.
 minversion = 4.0.2
-envlist = py38, py39, py310, py311, lint
+envlist = py39, py310, py311, py312, py313, lint
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Add support for Python 3.13

### Details and comments

At present I expect this to failed in the same way https://github.com/qiskit-community/qiskit-machine-learning/pull/836 is currently in this equivalent test here that was copied to "test.optimizers.test_gradient_descent.TestGradientDescent.test_start" when it tests a couple of dataclass equalities. I have a fix that works for me locally, see this comment in the above PR https://github.com/qiskit-community/qiskit-machine-learning/pull/836#issuecomment-2722614189 but I just wanted to see it failing in CI too before applying it just to make sure.

---

Will need branch rules updating for this change once its ok/approved.

