### PR TITLE
Update intersphinx mapping and other URLs pointing to IQP Classic

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2023, 2024.
+# (C) Copyright IBM 2023, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -122,7 +122,7 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "numpy": ("https://numpy.org/doc/stable", None),
     "scipy": ("https://docs.scipy.org/doc/scipy", None),
-    "qiskit": ("https://docs.quantum.ibm.com/api/qiskit/", None),
+    "qiskit": ("https://quantum.cloud.ibm.com/docs/api/qiskit/", None),
 }
 
 # -- Options for HTML output -------------------------------------------------

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -8,7 +8,7 @@ Installation
 ============
 
 Qiskit Algorithms depends on the main Qiskit package which has its own
-`Qiskit installation instructions <https://docs.quantum.ibm.com/start/install>`__ detailing the
+`Qiskit installation instructions <https://quantum.cloud.ibm.com/docs/guides/install-qiskit>`__ detailing the
 installation options for Qiskit and its supported environments/platforms. You should refer to
 that first, before focusing on the additional installation instructions
 specific to Qiskit Algorithms.
@@ -35,7 +35,7 @@ See :ref:`optional_installs` for more information.
 
        Since Qiskit Algorithms depends on Qiskit, and its latest changes may require new or changed
        features of Qiskit, you should first follow Qiskit's `"Install from source"` instructions
-       `here <https://docs.quantum.ibm.com/start/install-qiskit-source>`__
+       `here <https://quantum.cloud.ibm.com/docs/guides/install-qiskit-source>`__
 
        .. raw:: html
 

--- a/docs/tutorials/01_algorithms_introduction.ipynb
+++ b/docs/tutorials/01_algorithms_introduction.ipynb
@@ -83,7 +83,7 @@
     "\n",
     "Algorithms rely on the primitives to evaluate expectation values or sample circuits. The primitives can be based on a simulator or real device and can be used interchangeably in the algorithms, as they all implement the same interface.\n",
     "\n",
-    "In the VQE, we have to evaluate expectation values, so for example we can use the [qiskit.primitives.Estimator](https://docs.quantum.ibm.com/api/qiskit/qiskit.primitives.Estimator) which is shipped with the default Qiskit installation."
+    "In the VQE, we have to evaluate expectation values, so for example we can use the [qiskit.primitives.Estimator](https://quantum.cloud.ibm.com/docs/api/qiskit/qiskit.primitives.Estimator) which is shipped with the default Qiskit installation."
    ]
   },
   {
@@ -101,7 +101,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This estimator uses an exact, statevector simulation to evaluate the expectation values. We can also use a shot-based and noisy simulators or real backends instead. For more information of the simulators you can check out [Qiskit Aer](https://qiskit.github.io/qiskit-aer/apidocs/aer_primitives.html) and for the actual hardware [Qiskit IBM Runtime](https://docs.quantum.ibm.com/api/qiskit-ibm-runtime).\n",
+    "This estimator uses an exact, statevector simulation to evaluate the expectation values. We can also use a shot-based and noisy simulators or real backends instead. For more information of the simulators you can check out [Qiskit Aer](https://qiskit.github.io/qiskit-aer/apidocs/aer_primitives.html) and for the actual hardware [Qiskit IBM Runtime](https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime).\n",
     "\n",
     "With all the ingredients ready, we can now instantiate the VQE:"
    ]
@@ -211,7 +211,7 @@
     "\n",
     "To close off let's also change the estimator primitive inside the a VQE. Maybe you're satisfied with the simulation results and now want to use a shot-based simulator, or run on hardware!\n",
     "\n",
-    "In this example we're changing to a shot-based estimator, still using Qiskit's reference primitive. However, you could replace the primitive by e.g. Qiskit Aer's estimator ([qiskit_aer.primitives.Estimator](https://qiskit.github.io/qiskit-aer/stubs/qiskit_aer.primitives.Estimator.html#qiskit_aer.primitives.Estimator)) or even a real backend ([qiskit_ibm_runtime.Estimator](https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.Estimator)).\n",
+    "In this example we're changing to a shot-based estimator, still using Qiskit's reference primitive. However, you could replace the primitive by e.g. Qiskit Aer's estimator ([qiskit_aer.primitives.Estimator](https://qiskit.github.io/qiskit-aer/stubs/qiskit_aer.primitives.Estimator.html#qiskit_aer.primitives.Estimator)) or even a real backend ([qiskit_ibm_runtime.Estimator](https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/estimator)).\n",
     "\n",
     "For noisy loss functions, the SPSA optimizer typically performs well, so we also update the optimizer. See also the [noisy VQE tutorial](03_vqe_simulation_with_noise.ipynb) for more details on shot-based and noisy simulations."
    ]

--- a/docs/tutorials/02_vqe_advanced_options.ipynb
+++ b/docs/tutorials/02_vqe_advanced_options.ipynb
@@ -59,7 +59,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The next step is to instantiate the `Estimator` of choice for the evaluation of expectation values within `VQE`. For simplicity, you can select the [qiskit.primitives.Estimator](https://docs.quantum.ibm.com/api/qiskit/qiskit.primitives.Estimator) that comes as part of Qiskit."
+    "The next step is to instantiate the `Estimator` of choice for the evaluation of expectation values within `VQE`. For simplicity, you can select the [qiskit.primitives.Estimator](https://quantum.cloud.ibm.com/docs/api/qiskit/qiskit.primitives.Estimator) that comes as part of Qiskit."
    ]
   },
   {

--- a/docs/tutorials/03_vqe_simulation_with_noise.ipynb
+++ b/docs/tutorials/03_vqe_simulation_with_noise.ipynb
@@ -15,7 +15,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The algorithm of choice is once again VQE, where the task consists on finding the minimum (ground state) energy of a Hamiltonian. As shown in previous tutorials, VQE takes in a qubit operator as input. Here, you will take a set of Pauli operators that were originally computed by Qiskit Nature for the H2 molecule, using the [SparsePauliOp](https://docs.quantum.ibm.com/api/qiskit/qiskit.quantum_info.SparsePauliOp) class."
+    "The algorithm of choice is once again VQE, where the task consists on finding the minimum (ground state) energy of a Hamiltonian. As shown in previous tutorials, VQE takes in a qubit operator as input. Here, you will take a set of Pauli operators that were originally computed by Qiskit Nature for the H2 molecule, using the [SparsePauliOp](https://quantum.cloud.ibm.com/docs/api/qiskit/qiskit.quantum_info.SparsePauliOp) class."
    ]
   },
   {
@@ -388,7 +388,7 @@
    "source": [
     "You can notice that, while the noiseless simulation's result is closer to the exact reference value, there is still some difference. This is due to the sampling noise, introduced by limiting the number of shots to 1024. A larger number of shots would decrease this sampling error and close the gap between these two values.\n",
     "\n",
-    "As for the noise introduced by real devices (or simulated noise models), it could be tackled through a wide variety of error mitigation techniques. The [Qiskit Runtime Primitives](https://docs.quantum.ibm.com/api/qiskit-ibm-runtime) have enabled error mitigation through the `resilience_level` option. This option is currently available for remote simulators and real backends accessed via the Runtime Primitives, you can consult [this documentation](https://docs.quantum.ibm.com/run/configure-error-mitigation) for further information."
+    "As for the noise introduced by real devices (or simulated noise models), it could be tackled through a wide variety of error mitigation techniques. The [Qiskit Runtime Primitives](https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime) have enabled error mitigation through the `resilience_level` option. This option is currently available for remote simulators and real backends accessed via the Runtime Primitives, you can consult [this documentation](https://quantum.cloud.ibm.com/docs/guides/configure-error-mitigation) for further information."
    ]
   },
   {

--- a/docs/tutorials/10_pvqd.ipynb
+++ b/docs/tutorials/10_pvqd.ipynb
@@ -14,7 +14,7 @@
     "\\theta_{n+1} = \\theta_n + \\arg\\min_{\\delta\\theta} 1 - |\\langle\\phi(\\theta_n + \\delta\\theta)|e^{-i\\Delta_t H}|\\phi(\\theta_n)\\rangle|^2,\n",
     "$$\n",
     "\n",
-    "where $e^{-i\\Delta_t H}$ is calculated with a Trotter expansion (using e.g. the [PauliEvolutionGate](https://docs.quantum.ibm.com/api/qiskit/qiskit.circuit.library.PauliEvolutionGate) in Qiskit!).\n",
+    "where $e^{-i\\Delta_t H}$ is calculated with a Trotter expansion (using e.g. the [PauliEvolutionGate](https://quantum.cloud.ibm.com/docs/api/qiskit/qiskit.circuit.library.PauliEvolutionGate) in Qiskit!).\n",
     "\n",
     "The following tutorial explores the p-VQD algorithm, which is available as the [PVQD](https://qiskit-community.github.io/qiskit-algorithms/stubs/qiskit_algorithms.PVQD.html) class. For details on the algorithm, see the original paper: [Barison et al. Quantum 5, 512 (2021)](https://quantum-journal.org/papers/q-2021-07-28-512/#)."
    ]

--- a/docs/tutorials/12_gradients_framework.ipynb
+++ b/docs/tutorials/12_gradients_framework.ipynb
@@ -13,7 +13,7 @@
    },
    "source": [
     "# Gradient Framework\n",
-    "This tutorial demonstrates the use of the `qiskit_algorithms.gradients` module to evaluate quantum gradients using the [Qiskit Primitives](https://docs.quantum.ibm.com/api/qiskit/primitives).\n",
+    "This tutorial demonstrates the use of the `qiskit_algorithms.gradients` module to evaluate quantum gradients using the [Qiskit Primitives](https://quantum.cloud.ibm.com/docs/api/qiskit/primitives).\n",
     "\n",
     "## Introduction\n",
     "The gradient frameworks allows the evaluation of quantum gradients (see [Schuld et al.](https://journals.aps.org/pra/abstract/10.1103/PhysRevA.99.032331) and [Mari et al.](https://journals.aps.org/pra/abstract/10.1103/PhysRevA.103.012405)).\n",

--- a/docs/tutorials/13_trotterQRTE.ipynb
+++ b/docs/tutorials/13_trotterQRTE.ipynb
@@ -49,7 +49,7 @@
     "| $\\ldots$                 | $\\ldots$                                   |\n",
     "| $\\lvert 1 1 1 1 \\rangle$ | $\\downarrow\\downarrow\\downarrow\\downarrow$ |\n",
     "\n",
-    "First, we will create a function that takes in the system parameters $L$, $J$, $h$ and $\\alpha$, and returns our Hamiltonian as a `SparsePauliOp`. A [SparsePauliOp](https://docs.quantum.ibm.com/api/qiskit/qiskit.quantum_info.SparsePauliOp) is a sparse representation of an operator in terms of weighted [Pauli](https://docs.quantum.ibm.com/api/qiskit/qiskit.quantum_info.Pauli) terms."
+    "First, we will create a function that takes in the system parameters $L$, $J$, $h$ and $\\alpha$, and returns our Hamiltonian as a `SparsePauliOp`. A [SparsePauliOp](https://quantum.cloud.ibm.com/docs/api/qiskit/qiskit.quantum_info.SparsePauliOp) is a sparse representation of an operator in terms of weighted [Pauli](https://quantum.cloud.ibm.com/docs/api/qiskit/qiskit.quantum_info.Pauli) terms."
    ]
   },
   {
@@ -198,7 +198,7 @@
    "id": "6b207d17-7633-40b6-b70e-3788966c4fb8",
    "metadata": {},
    "source": [
-    "By sequentially decomposing the circuit, we can show it in terms of Qiskit's [Circuit Library](https://docs.quantum.ibm.com/api/qiskit/circuit_library) standard gates."
+    "By sequentially decomposing the circuit, we can show it in terms of Qiskit's [Circuit Library](https://quantum.cloud.ibm.com/docs/api/qiskit/circuit_library) standard gates."
    ]
   },
   {
@@ -547,7 +547,7 @@
     "\\vert \\psi(t) \\rangle = e^{-i H t} \\vert \\psi(0) \\rangle \\text{,}\n",
     "$$\n",
     "\n",
-    "on each one of the timesteps used by Trotter. We compute this exponential using SciPy's [linalg.expm](https://docs.scipy.org/doc/scipy/reference/generated/scipy.linalg.expm.html) function, and then we let the initial system evolve using the `Statevector`'s [evolve](https://docs.quantum.ibm.com/api/qiskit/qiskit.quantum_info.Statevector#evolve) method. This becomes too costly to be performed on larger systems very quickly."
+    "on each one of the timesteps used by Trotter. We compute this exponential using SciPy's [linalg.expm](https://docs.scipy.org/doc/scipy/reference/generated/scipy.linalg.expm.html) function, and then we let the initial system evolve using the `Statevector`'s [evolve](https://quantum.cloud.ibm.com/docs/api/qiskit/qiskit.quantum_info.Statevector#evolve) method. This becomes too costly to be performed on larger systems very quickly."
    ]
   },
   {
@@ -646,7 +646,7 @@
    "source": [
     "### Product formula overview\n",
     "\n",
-    "If it isn't specified, the default product formula that `TrotterQRTE` uses is the Lie product formula [2], which is at first order. In Qiskit this is implemented in the [LieTrotter](https://docs.quantum.ibm.com/api/qiskit/qiskit.synthesis.LieTrotter) class. A first order formula consists of the approximation stated in the introduction, where the matrix exponential of a sum is approximated by a product of matrix exponentials:\n",
+    "If it isn't specified, the default product formula that `TrotterQRTE` uses is the Lie product formula [2], which is at first order. In Qiskit this is implemented in the [LieTrotter](https://quantum.cloud.ibm.com/docs/api/qiskit/qiskit.synthesis.LieTrotter) class. A first order formula consists of the approximation stated in the introduction, where the matrix exponential of a sum is approximated by a product of matrix exponentials:\n",
     "\n",
     "$$\n",
     "e^{A+B} \\approx e^A e^B\n",
@@ -729,7 +729,7 @@
    "id": "ad8c6b98-eb15-497f-ba17-35402c0f8a22",
    "metadata": {},
    "source": [
-    "There exists a second-order formula, called the Suzuki-Trotter decomposition [3], and can be used in Qiskit by means of the [SuzukiTrotter class](https://docs.quantum.ibm.com/api/qiskit/qiskit.synthesis.SuzukiTrotter). Using this formula, a second order decomposition is:\n",
+    "There exists a second-order formula, called the Suzuki-Trotter decomposition [3], and can be used in Qiskit by means of the [SuzukiTrotter class](https://quantum.cloud.ibm.com/docs/api/qiskit/qiskit.synthesis.SuzukiTrotter). Using this formula, a second order decomposition is:\n",
     "\n",
     "$$\n",
     "e^{A+B} \\approx e^{B/2}e^{A}e^{B/2}\n",

--- a/qiskit_algorithms/__init__.py
+++ b/qiskit_algorithms/__init__.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2018, 2024.
+# (C) Copyright IBM 2018, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_algorithms/__init__.py
+++ b/qiskit_algorithms/__init__.py
@@ -31,7 +31,7 @@ These elements are frequently used in a variety of applications, such as variati
 time evolution and quantum machine learning.
 
 The quantum algorithms here all use
-`Primitives <https://docs.quantum.ibm.com/run/primitives>`__
+`Primitives <https://quantum.cloud.ibm.com/docs/guides/primitives>`__
 to execute quantum circuits. This can be an
 ``Estimator``, which computes expectation values, or a ``Sampler`` which computes
 probability distributions. Refer to the specific algorithm for more information in this regard.

--- a/releasenotes/notes/0.3/qiskit_1_0_compatible-405b357d032fbeeb.yaml
+++ b/releasenotes/notes/0.3/qiskit_1_0_compatible-405b357d032fbeeb.yaml
@@ -1,5 +1,5 @@
 ---
 prelude: >
-    This release now supports `Qiskit 1.0 <https://docs.quantum.ibm.com/api/qiskit/release-notes/1.0>`__
+    This release now supports `Qiskit 1.0 <https://quantum.cloud.ibm.com/docs/api/qiskit/release-notes/1.0>`__
     while continuing to work with the Qiskit 0.46 release for those still navigating the changes brought
     about in the Qiskit 1.0 release.


### PR DESCRIPTION
The documentation source of truth is moving to https://quantum.cloud.ibm.com/.