### PR TITLE
Fix getter/setter type mismatch

### DIFF
--- a/qiskit_algorithms/variational_algorithm.py
+++ b/qiskit_algorithms/variational_algorithm.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2019, 2023.
+# (C) Copyright IBM 2019, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -91,7 +91,7 @@ class VariationalResult(AlgorithmResult):
         return self._optimal_value
 
     @optimal_value.setter
-    def optimal_value(self, value: int) -> None:
+    def optimal_value(self, value: float) -> None:
         """Sets optimal value"""
         self._optimal_value = value
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This mismatch (optimal_value setter/getter type not the same) was noticed and corrected recently in Qiskit Optimization see qiskit-community/qiskit-optimization#664


### Details and comments


