### PR TITLE
Fix tests to accomodate scipy 1.16.0 changes

### DIFF
--- a/test/eigensolvers/test_vqd.py
+++ b/test/eigensolvers/test_vqd.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2024.
+# (C) Copyright IBM 2022, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -16,7 +16,9 @@ import unittest
 from test import QiskitAlgorithmsTestCase
 
 import numpy as np
+import scipy
 from ddt import data, ddt
+from packaging.version import Version
 
 from qiskit import QuantumCircuit
 from qiskit.circuit.library import TwoLocal, RealAmplitudes
@@ -175,7 +177,7 @@ class TestVQD(QiskitAlgorithmsTestCase):
             history["metadata"].append(metadata)
             history["step"].append(step)
 
-        optimizer = COBYLA(maxiter=3)
+        optimizer = COBYLA(maxiter=12)
         wavefunction = self.ry_wavefunction
 
         vqd = VQD(
@@ -185,6 +187,7 @@ class TestVQD(QiskitAlgorithmsTestCase):
             optimizer=optimizer,
             callback=store_intermediate_result,
             betas=self.betas,
+            initial_point=[1] * 8,
         )
 
         vqd.compute_eigenvalues(operator=op)
@@ -196,11 +199,98 @@ class TestVQD(QiskitAlgorithmsTestCase):
         for params in history["parameters"]:
             self.assertTrue(all(isinstance(param, float) for param in params))
 
-        ref_eval_count = [1, 2, 3, 1, 2, 3]
-        ref_mean = [-1.07, -1.45, -1.36, 1.24, 1.55, 1.07]
-        # new ref_mean since the betas were changed
+        ref_eval_count = [
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12,
+        ]
 
-        ref_step = [1, 1, 1, 2, 2, 2]
+        ref_mean_pre_1_16 = [
+            -1.08,
+            -1.08,
+            -1.0,
+            -1.14,
+            -1.17,
+            -1.38,
+            -1.0,
+            -1.63,
+            -1.45,
+            -1.55,
+            -1.63,
+            -1.75,
+            -1.04,
+            -1.07,
+            -0.72,
+            -0.46,
+            -0.71,
+            -0.56,
+            -0.92,
+            -0.29,
+            -0.89,
+            -0.38,
+            -1.06,
+            -1.05,
+        ]
+        ref_mean_1_16 = [
+            -1.08,
+            -1.08,
+            -1.0,
+            -1.14,
+            -1.17,
+            -1.38,
+            -1.0,
+            -1.63,
+            -1.45,
+            -1.55,
+            -1.63,
+            -1.75,
+            -1.04,
+            -1.07,
+            -0.72,
+            -0.46,
+            -0.71,
+            -0.56,
+            -0.92,
+            -0.29,
+            -0.89,
+            -0.38,
+            -0.97,
+            -1.16,
+        ]
+        # Unlike in other places where COYBLA is used in tests and differences arose between
+        # pre 1.16.0 versions and after, where in 1.16.0 scipy changed the COBYLA
+        # implementation, I was not able to find changes that would reproduce the outcome so
+        # tests passed no matter whether 1.16 or before was installed. Here the mean outcomes
+        # match all but the last 2 values so I thought about comparing a subset but in the
+        # end decided to go with different reference values based on scipy version
+        ref_mean = (
+            ref_mean_pre_1_16
+            if Version(scipy.version.version) < Version("1.16.0")
+            else ref_mean_1_16
+        )
+
+        ref_step = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2]
 
         np.testing.assert_array_almost_equal(history["eval_count"], ref_eval_count, decimal=0)
         np.testing.assert_array_almost_equal(history["mean"], ref_mean, decimal=2)
@@ -410,7 +500,7 @@ class TestVQD(QiskitAlgorithmsTestCase):
                 0.2442925,
                 -1.51638917,
             ],
-            optimizer=COBYLA(maxiter=0),
+            optimizer=COBYLA(maxiter=10),
             betas=self.betas,
         )
 
@@ -423,7 +513,7 @@ class TestVQD(QiskitAlgorithmsTestCase):
         # expectation values
         self.assertAlmostEqual(result.aux_operators_evaluated[0][0][0], 2.0, places=1)
         self.assertAlmostEqual(
-            result.aux_operators_evaluated[0][1][0], 0.0019531249999999445, places=1
+            result.aux_operators_evaluated[0][1][0], 0.7432341813894455, places=1
         )
         # metadata
         self.assertIsInstance(result.aux_operators_evaluated[0][0][1], dict)
@@ -435,9 +525,7 @@ class TestVQD(QiskitAlgorithmsTestCase):
         self.assertEqual(len(result.aux_operators_evaluated[0]), 4)
         # expectation values
         self.assertAlmostEqual(result.aux_operators_evaluated[0][0][0], 2.0, places=1)
-        self.assertAlmostEqual(
-            result.aux_operators_evaluated[0][1][0], 0.0019531249999999445, places=1
-        )
+        self.assertAlmostEqual(result.aux_operators_evaluated[0][1][0], 0.743234181389445, places=1)
         self.assertEqual(result.aux_operators_evaluated[0][2][0], 0.0)
         self.assertEqual(result.aux_operators_evaluated[0][3][0], 0.0)
         # metadata

--- a/test/minimum_eigensolvers/test_qaoa.py
+++ b/test/minimum_eigensolvers/test_qaoa.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2023.
+# (C) Copyright IBM 2022, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -180,7 +180,7 @@ class TestQAOA(QiskitAlgorithmsTestCase):
         with self.subTest(msg="QAOA 6x6"):
             self.assertIn(graph_solution, {"010101", "101010"})
 
-    @idata([[W2, S2, None], [W2, S2, [0.0, 0.0]], [W2, S2, [1.0, 0.8]]])
+    @idata([[W2, S2, None], [W2, S2, [0.0, 0.5]], [W2, S2, [1.0, 0.8]]])
     @unpack
     def test_qaoa_initial_point(self, w, solutions, init_pt):
         """Check first parameter value used is initial point as expected"""

--- a/test/minimum_eigensolvers/test_sampling_vqe.py
+++ b/test/minimum_eigensolvers/test_sampling_vqe.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2018, 2024.
+# (C) Copyright IBM 2018, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -185,10 +185,10 @@ class TestSamplerVQE(QiskitAlgorithmsTestCase):
         vqe = SamplingVQE(
             Sampler(),
             RealAmplitudes(),
-            partial(scipy_minimize, method="COBYLA", options={"maxiter": 2}),
+            partial(scipy_minimize, method="COBYLA", options={"maxiter": 8}),
         )
         result = vqe.compute_minimum_eigenvalue(Pauli("Z"))
-        self.assertEqual(result.cost_function_evals, 2)
+        self.assertEqual(result.cost_function_evals, 8)
 
     def test_optimizer_callable(self):
         """Test passing a optimizer directly as callable."""

--- a/test/optimizers/test_optimizers.py
+++ b/test/optimizers/test_optimizers.py
@@ -75,7 +75,7 @@ class TestOptimizers(QiskitAlgorithmsTestCase):
             grad: Whether to pass the gradient function as input.
             bounds: Optimizer bounds.
         """
-        x_0 = np.asarray([1.3, 0.7, 0.8, 1.9, 1.2])
+        x_0 = np.asarray([1.13, 0.7, 0.8, 1.9, 1.2])
         jac = rosen_der if grad else None
 
         res = optimizer.minimize(rosen, x_0, jac, bounds)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes #233 

Fixes nightly CI failures that arose when scipy 1.16.0 was released recently

### Details and comments

In scipy 1.16.0 the COYLA implementation was changed

https://docs.scipy.org/doc/scipy/reference/optimize.minimize-cobyla.html

> Changed in version 1.16.0: The original Powell implementation was replaced by a pure Python version from the PRIMA package, with bug fixes and improvements being made.

and this seems to have affected a few CI tests here that failed

```
==============================
Failed 6 tests - output below:
==============================

test.eigensolvers.test_vqd.TestVQD.test_callback_1
--------------------------------------------------

Captured traceback:
~~~~~~~~~~~~~~~~~~~
    Traceback (most recent call last):

      File "/opt/hostedtoolcache/Python/3.12.10/x64/lib/python3.12/site-packages/ddt.py", line 221, in wrapper
    return func(self, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^

      File "/home/runner/work/qiskit-algorithms/qiskit-algorithms/test/eigensolvers/test_vqd.py", line 205, in test_callback
    np.testing.assert_array_almost_equal(history["eval_count"], ref_eval_count, decimal=0)

      File "/opt/hostedtoolcache/Python/3.12.10/x64/lib/python3.12/site-packages/numpy/testing/_private/utils.py", line 1175, in assert_array_almost_equal
    assert_array_compare(compare, actual, desired, err_msg=err_msg,

      File "/opt/hostedtoolcache/Python/3.12.10/x64/lib/python3.12/site-packages/numpy/testing/_private/utils.py", line 813, in assert_array_compare
    raise AssertionError(msg)

    AssertionError: 
Arrays are not almost equal to 0 decimals

(shapes (20,), (6,) mismatch)
 ACTUAL: array([ 1,  2,  3,  4,  5,  6,  7,  8,  9, 10,  1,  2,  3,  4,  5,  6,  7,
        8,  9, 10])
 DESIRED: array([1, 2, 3, 1, 2, 3])


test.eigensolvers.test_vqd.TestVQD.test_aux_operator_std_dev_1
--------------------------------------------------------------

Captured traceback:
~~~~~~~~~~~~~~~~~~~
    Traceback (most recent call last):

      File "/opt/hostedtoolcache/Python/3.12.10/x64/lib/python3.12/site-packages/ddt.py", line 221, in wrapper
    return func(self, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^

      File "/home/runner/work/qiskit-algorithms/qiskit-algorithms/test/eigensolvers/test_vqd.py", line 425, in test_aux_operator_std_dev
    self.assertAlmostEqual(

      File "/opt/hostedtoolcache/Python/3.12.10/x64/lib/python3.12/unittest/case.py", line 939, in assertAlmostEqual
    raise self.failureException(msg)

    AssertionError: np.float64(0.743234181389445) != 0.0019531249999999445 within 1 places (np.float64(0.741281056389445) difference)


test.minimum_eigensolvers.test_qaoa.TestQAOA.test_qaoa_initial_point_2
----------------------------------------------------------------------

Captured traceback:
~~~~~~~~~~~~~~~~~~~
    Traceback (most recent call last):

      File "/opt/hostedtoolcache/Python/3.12.10/x64/lib/python3.12/site-packages/ddt.py", line 221, in wrapper
    return func(self, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^

      File "/home/runner/work/qiskit-algorithms/qiskit-algorithms/test/minimum_eigensolvers/test_qaoa.py", line 215, in test_qaoa_initial_point
    self.assertIn(graph_solution, solutions)

      File "/opt/hostedtoolcache/Python/3.12.10/x64/lib/python3.12/unittest/case.py", line 1152, in assertIn
    self.fail(self._formatMessage(msg, standardMsg))

      File "/opt/hostedtoolcache/Python/3.12.10/x64/lib/python3.12/unittest/case.py", line 715, in fail
    raise self.failureException(msg)

    AssertionError: '1111' not found in {'0100', '1011'}


test.minimum_eigensolvers.test_qaoa.TestQAOA.test_qaoa_qc_mixer_many_parameters
-------------------------------------------------------------------------------

Captured traceback:
~~~~~~~~~~~~~~~~~~~
    Traceback (most recent call last):

      File "/home/runner/work/qiskit-algorithms/qiskit-algorithms/test/minimum_eigensolvers/test_qaoa.py", line 137, in test_qaoa_qc_mixer_many_parameters
    self.assertIn(graph_solution, S1)

      File "/opt/hostedtoolcache/Python/3.12.10/x64/lib/python3.12/unittest/case.py", line 1152, in assertIn
    self.fail(self._formatMessage(msg, standardMsg))

      File "/opt/hostedtoolcache/Python/3.12.10/x64/lib/python3.12/unittest/case.py", line 715, in fail
    raise self.failureException(msg)

    AssertionError: '110' not found in {'1010', '0101'}


test.minimum_eigensolvers.test_sampling_vqe.TestSamplerVQE.test_optimizer_scipy_callable
----------------------------------------------------------------------------------------

Captured traceback:
~~~~~~~~~~~~~~~~~~~
    Traceback (most recent call last):

      File "/home/runner/work/qiskit-algorithms/qiskit-algorithms/test/minimum_eigensolvers/test_sampling_vqe.py", line 191, in test_optimizer_scipy_callable
    self.assertEqual(result.cost_function_evals, 2)

      File "/opt/hostedtoolcache/Python/3.12.10/x64/lib/python3.12/unittest/case.py", line 885, in assertEqual
    assertion_func(first, second, msg=msg)

      File "/opt/hostedtoolcache/Python/3.12.10/x64/lib/python3.12/unittest/case.py", line 878, in _baseAssertEqual
    raise self.failureException(msg)

    AssertionError: np.int64(6) != 2


test.optimizers.test_optimizers.TestOptimizers.test_cobyla
----------------------------------------------------------

Captured traceback:
~~~~~~~~~~~~~~~~~~~
    Traceback (most recent call last):

      File "/home/runner/work/qiskit-algorithms/qiskit-algorithms/test/optimizers/test_optimizers.py", line 106, in test_cobyla
    self.run_optimizer(optimizer, max_nfev=100000)

      File "/home/runner/work/qiskit-algorithms/qiskit-algorithms/test/optimizers/test_optimizers.py", line 85, in run_optimizer
    np.testing.assert_array_almost_equal(x_opt, [1.0] * len(x_0), decimal=2)

      File "/opt/hostedtoolcache/Python/3.12.10/x64/lib/python3.12/site-packages/numpy/testing/_private/utils.py", line 1175, in assert_array_almost_equal
    assert_array_compare(compare, actual, desired, err_msg=err_msg,

      File "/opt/hostedtoolcache/Python/3.12.10/x64/lib/python3.12/site-packages/numpy/testing/_private/utils.py", line 926, in assert_array_compare
    raise AssertionError(msg)

    AssertionError: 
Arrays are not almost equal to 2 decimals

Mismatched elements: 5 / 5 (100%)
Max absolute difference among violations: 1.96222778
Max relative difference among violations: 1.96222778
 ACTUAL: array([-0.96,  0.94,  0.88,  0.78,  0.61])
 DESIRED: array([1., 1., 1., 1., 1.])
 ```
 
 What I did, in the main, was to adjust tests, say the initial point or some other parameter to have them pass in 1.16 as well as pre that e.g 1.15.3 
 

- This failure for example `AssertionError: np.int64(6) != 2` seems to be that setting maxiter=2 no longer resulted in 2 functional evals but 6! Setting it to 8 seemed to have it stop at 8 functional evals
-  test_qaoa and test_optimizers I adjusted the initial point
- test_vqd was more complicated and I could not find a setting that passed for both. I had to increase maxiter so as to get a consistent number of evals but then the mean outputs recorded by the callback being tested did not end up identical despite me trying different initial points etc. In the end I got things close to where only the last 2 entries in the list varied. I was going to check the list up to those entries ie add [0:-2] to subset the list. In the end I chose to detect the scipy version and switch according which reference mean list was used.

It passed locally for me under 3.12 using either 1.15.3 or 1.16.0 - lets see here in CI. I looked in scipy github but did not see any issues that might be relevant. I guess with an implementation switch only time will tell how this works out for the CI tests here.
 
 