### PR TITLE
Update copyright dates following #197 merge

### DIFF
--- a/qiskit_algorithms/algorithm_job.py
+++ b/qiskit_algorithms/algorithm_job.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2024.
+# (C) Copyright IBM 2022, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_algorithms/custom_types.py
+++ b/qiskit_algorithms/custom_types.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2024.
+# (C) Copyright IBM 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_algorithms/phase_estimators/phase_estimator.py
+++ b/qiskit_algorithms/phase_estimators/phase_estimator.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2020, 2024.
+# (C) Copyright IBM 2020, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

#197 passed CI checks and was merged but the CI action taken once the branch changes were merged to main failed as below,

```
Wrong Copyright Year:'qiskit_algorithms/custom_types.py':  Current:'# (C) Copyright IBM 2024.' Correct:'# (C) Copyright IBM 2024, 2025.'
Wrong Copyright Year:'qiskit_algorithms/phase_estimators/phase_estimator.py':  Current:'# (C) Copyright IBM 2020, 2024.' Correct:'# (C) Copyright IBM 2020, 2025.'
Wrong Copyright Year:'qiskit_algorithms/algorithm_job.py':  Current:'# (C) Copyright IBM 2022, 2024.' Correct:'# (C) Copyright IBM 2022, 2025.'
0 files have utf8 headers.
3 of 231 files with copyright header have wrong years.
```

This updates the copyright dates for those 3 files, which were last changed in 2024 before the merge commit. I think we have seen this in the past a couple of times with the copyright checker.

### Details and comments

The failing action itself
https://github.com/qiskit-community/qiskit-algorithms/actions/runs/16779229860/job/47513061014
