### PR TITLE
Fixed QNSPSA docstring

### DIFF
--- a/qiskit_algorithms/optimizers/qnspsa.py
+++ b/qiskit_algorithms/optimizers/qnspsa.py
@@ -76,8 +76,7 @@ class QNSPSA(SPSA):
             estimator = StatevectorEstimator()
 
             def loss(x):
-                result = estimator.run([(ansatz, observable, x)]).result()[0]
-                return np.real(result.data.evs) # pylint: disable=wrong-spelling-in-docstring
+                return estimator.run([(ansatz, observable, x)]).result()[0].data.evs
 
             # fidelity for estimation of the geometric tensor
             sampler = StatevectorSampler()

--- a/qiskit_algorithms/optimizers/qnspsa.py
+++ b/qiskit_algorithms/optimizers/qnspsa.py
@@ -77,7 +77,7 @@ class QNSPSA(SPSA):
 
             def loss(x):
                 result = estimator.run([(ansatz, observable, x)]).result()[0]
-                return np.real(result.data.evs)
+                return np.real(result.data.evs) # pylint: disable=wrong-spelling-in-docstring
 
             # fidelity for estimation of the geometric tensor
             sampler = StatevectorSampler()

--- a/qiskit_algorithms/optimizers/qnspsa.py
+++ b/qiskit_algorithms/optimizers/qnspsa.py
@@ -77,7 +77,7 @@ class QNSPSA(SPSA):
 
             def loss(x):
                 result = estimator.run([(ansatz, observable, x)]).result()[0]
-                return np.real(result.data.evs[0])
+                return np.real(result.data.evs)
 
             # fidelity for estimation of the geometric tensor
             sampler = StatevectorSampler()
@@ -85,7 +85,7 @@ class QNSPSA(SPSA):
 
             # run QN-SPSA
             qnspsa = QNSPSA(fidelity, maxiter=300)
-            result = qnspsa.optimize(ansatz.num_parameters, loss, initial_point=initial_point)
+            result = qnspsa.minimize(loss, x0=initial_point)
 
     References:
 


### PR DESCRIPTION
### Summary
Fixes #163. As described there, the docstring for `QNSPSA` still used the `optimize` method instead of the `minimize` one. This PR corrects this.