### PR TITLE
Added 2.1.2 to caught versions of Qiskit in AdaptVQE

### DIFF
--- a/qiskit_algorithms/minimum_eigensolvers/adapt_vqe.py
+++ b/qiskit_algorithms/minimum_eigensolvers/adapt_vqe.py
@@ -238,9 +238,9 @@ class AdaptVQE(VariationalAlgorithm, MinimumEigensolver):
         # The excitations operators are applied later as exp(i*theta*excitation).
         # For this commutator, we need to explicitly pull in the imaginary phase.
         commutators = [1j * (operator @ exc - exc @ operator) for exc in self._excitation_pool]
-        # We have to call simplify on it since Qiskit doesn't do so in versions 2.1.0 and 2.1.1, see
+        # We have to call simplify on it since Qiskit doesn't do so in versions 2.1.X, see
         # Qiskit/qiskit/issues/14567
-        if get_qiskit_version_info() in ["2.1.0", "2.1.1"]:
+        if get_qiskit_version_info() in ["2.1.0", "2.1.1", "2.1.2"]:
             commutators = [obs.simplify() for obs in commutators]
 
         # If the ansatz has been transpiled

--- a/releasenotes/notes/fix-adaptvqe-qiskit-2.1.2-8ca695d06e88e972.yaml
+++ b/releasenotes/notes/fix-adaptvqe-qiskit-2.1.2-8ca695d06e88e972.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    :class:`.AdaptVQE` now works correctly when using qiskit in version 2.1.2.


### PR DESCRIPTION
### Summary

As per [this comment in #244](https://github.com/qiskit-community/qiskit-algorithms/issues/244#issuecomment-3241698362), https://github.com/Qiskit/qiskit/pull/14714 will only be merged in the `2.2.0` release of Qiskit. As such, Qiskit/qiskit#14567 is still a problem in the `2.1.2` release.

We thus need to `simplify` the `commutators` ourselves in `AdaptVQE` in this qiskit release. This was already done for the `2.1.0` and `2.1.2` releases. This PR adds the `2.1.2` release to the versions in which to perform this additional operation.

This would prevent users from encountering errors when running `AdaptVQE`.

Note: this doesn't preclude having to pin the qiskit version to be different than `2.1.2` in `requirements-dev.txt`, since Qiskit/qiskit#14611 is not fixed in the `2.1.2` release either. However, while the later may not be encountered by users, it's way less certain for this issue, as seen from the fact that even basic unit test fail to pass when using `AdaptVQE` with qiskit `2.1.2`.
