### PR TITLE
Fix layout not applied when running on hardware

### DIFF
--- a/qiskit_algorithms/minimum_eigensolvers/diagonal_estimator.py
+++ b/qiskit_algorithms/minimum_eigensolvers/diagonal_estimator.py
@@ -75,13 +75,24 @@ class _DiagonalEstimator(BaseEstimatorV2):
 
     # If precision is set to None, the default number of shots of the Sampler will be used. It will
     # otherwise be computed as a function of the observable and the precision
-    def run(
-        self, pubs: Iterable[EstimatorPubLike], *, precision: float | None = None
-    ) -> AlgorithmJob[PrimitiveResult[_DiagonalEstimatorResult]]:
+    def run(self, pubs: Iterable[EstimatorPubLike], *, precision=None):
+        aligned_pubs = []
+        for pub in pubs:
+            circ, obs, *rest = pub
+    
+            # If the circuit has a layout and the observable doesn't, align them.
+            if hasattr(circ, "layout") and circ.layout is not None:
+                try:
+                    obs = obs.apply_layout(layout=circ.layout)
+                except Exception:
+                    # If the observable can't apply the layout, skip silently
+                    pass
+
+            aligned_pubs.append((circ, obs, *rest))
+
         # Since we will convert the standalone observables to a list, this `observables` list will
         # remember the shape of the original observables, either standalone or in a list.
-        coerced_pubs = [EstimatorPub.coerce(pub, precision) for pub in pubs]
-
+        coerced_pubs = [EstimatorPub.coerce(pub, precision) for pub in aligned_pubs]
         job = AlgorithmJob(self._run, coerced_pubs)
         job._submit()
         return job


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This PR fix issue when running QAOA on hardware. 
Specifically, it solves observable dimension not matching the circuit's layout, e.g.:

`ValueError: The number of qubits of the circuit (133) does not match the number of qubits of the ()-th observable (16).`

### Details and comments

The PR applies the circuit layout to the observable if the circuit has a layout.
