### PR TITLE
Fix sign typo in VarQTE tutorial metric formula

### DIFF
--- a/docs/tutorials/11_VarQTE.ipynb
+++ b/docs/tutorials/11_VarQTE.ipynb
@@ -40,14 +40,16 @@
     "\n",
     "where\n",
     "\n",
-    "$$F_{ij}=\\text{Re}\\left[\\frac{\\partial\\left\\langle \\psi\\left[\\theta\\right]\\right|}{\\partial\\theta_{i}}\\frac{\\partial\\left|\\psi\\left[\\theta\\right]\\right\\rangle }{\\partial\\theta_{j}}+\\frac{\\partial\\left\\langle \\psi\\left[\\theta\\right]\\right|}{\\partial\\theta_{i}}\\left|\\psi\\left[\\theta\\right]\\right\\rangle \\left\\langle \\psi\\left[\\theta\\right]\\right|\\frac{\\partial\\left|\\psi\\left[\\theta\\right]\\right\\rangle }{\\partial\\theta_{j}}\\right]$$,\n",
+    "$$F_{ij}=\\text{Re}\\left[\\frac{\\partial\\left\\langle \\psi\\left[\\theta\\right]\\right|}{\\partial\\theta_{i}}\\frac{\\partial\\left|\\psi\\left[\\theta\\right]\\right\\rangle }{\\partial\\theta_{j}}-\\frac{\\partial\\left\\langle \\psi\\left[\\theta\\right]\\right|}{\\partial\\theta_{i}}\\left|\\psi\\left[\\theta\\right]\\right\\rangle \\left\\langle \\psi\\left[\\theta\\right]\\right|\\frac{\\partial\\left|\\psi\\left[\\theta\\right]\\right\\rangle }{\\partial\\theta_{j}}\\right]$$\n",
+    ",\n",
     "\n",
     "and\n",
     "\n",
     "$$V_{i}=\\begin{cases}\n",
     "\\text{Im}\\left[\\frac{\\partial\\left\\langle \\psi\\left[\\theta\\right]\\right|}{\\partial\\theta_{i}}H\\left|\\psi\\left[\\theta\\right]\\right\\rangle +\\left\\langle \\psi\\left[\\theta\\right]\\right|\\frac{\\partial\\left|\\psi\\left[\\theta\\right]\\right\\rangle }{\\partial\\theta_{i}}\\left\\langle H\\right\\rangle _{\\theta}\\right] & \\text{Real time}\\\\\n",
     "-\\text{Re}\\left[\\frac{\\partial\\left\\langle \\psi\\left[\\theta\\right]\\right|}{\\partial\\theta_{i}}H\\left|\\psi\\left[\\theta\\right]\\right\\rangle \\right] & \\text{Imaginary time}\n",
-    "\\end{cases}$$."
+    "\\end{cases}$$\n",
+    "."
    ]
   },
   {


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fix a sign typo in the McLachlan metric formula in `docs/tutorials/11_VarQTE.ipynb`.

The tutorial currently shows

`F_ij = Re(<∂iψ|∂jψ> + <∂iψ|ψ><ψ|∂jψ>)`

but the implementation used in Qiskit (e.g. `LinCombQGT`) corresponds to the projected quantum geometric tensor metric

`F_ij = Re(<∂iψ|∂jψ> - <∂iψ|ψ><ψ|∂jψ>)`

This PR flips the sign so the tutorial matches the metric used in the implementation.

Fixes #266 

### Details and comments

This is a documentation-only change in the tutorial notebook `docs/tutorials/11_VarQTE.ipynb`.

I also moved the punctuation outside the display-math block so the equation renders correctly in stricter notebook renderers.


