### PR TITLE
Removed support for Python 3.9 and Added support for Python 3.14

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2025.
+# (C) Copyright IBM 2021, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -36,7 +36,7 @@ runs:
         if [ "${{ inputs.event-name }}" == "schedule" ] || [ "${{ inputs.run-slow }}" == "true" ]; then
           export QISKIT_TESTS="run_slow"
         fi
-        if [ "${{ inputs.os }}" == "ubuntu-latest" ] && [ "${{ inputs.python-version }}" == "3.9" ]; then
+        if [ "${{ inputs.os }}" == "ubuntu-latest" ] && [ "${{ inputs.python-version }}" == "3.10" ]; then
           export PYTHON="coverage3 run --source qiskit_algorithms --parallel-mode"
         fi
         stestr --test-path test run 2> >(tee /dev/stderr out.txt > /dev/null)

--- a/.github/workflows/deploy-code.yml
+++ b/.github/workflows/deploy-code.yml
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2025.
+# (C) Copyright IBM 2021, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -25,7 +25,7 @@ jobs:
       id-token: write
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version: [3.10]
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v6

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2025.
+# (C) Copyright IBM 2021, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -36,7 +36,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.9]
+        python-version: ['3.14']
     steps:
       - name: Print Concurrency Group
         env:
@@ -111,16 +111,16 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.9, '3.10', 3.11, 3.12, 3.13]
+        python-version: ['3.10', 3.11, 3.12, 3.13, 3.14]
         include:
           - os: macos-latest
-            python-version: 3.9
+            python-version: '3.10'
           - os: macos-latest
-            python-version: 3.13
+            python-version: 3.14
           - os: windows-latest
-            python-version: 3.9
+            python-version: '3.10'
           - os: windows-latest
-            python-version: 3.13
+            python-version: 3.14
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v6
@@ -159,7 +159,7 @@ jobs:
         run: |
           coverage3 combine
           mv .coverage ./ci-artifact-data/alg.dat
-        if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == 3.9 }}
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.10' }}
         shell: bash
       - uses: actions/upload-artifact@v5
         with:
@@ -172,7 +172,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.9, 3.13]
+        python-version: ['3.10', 3.14]
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v6
@@ -209,7 +209,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.9, 3.13]
+        python-version: ['3.10', 3.14]
     steps:
       - uses: actions/checkout@v5
         with:
@@ -255,16 +255,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version: ['3.10']
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: actions/download-artifact@v6
-        with:
-          name: ubuntu-latest-3.9
-          path: /tmp/u39
       - uses: actions/download-artifact@v6
         with:
           name: ubuntu-latest-3.10
@@ -283,29 +279,33 @@ jobs:
           path: /tmp/u313
       - uses: actions/download-artifact@v6
         with:
-          name: macos-latest-3.9
-          path: /tmp/m39
+          name: ubuntu-latest-3.14
+          path: /tmp/u314
       - uses: actions/download-artifact@v6
         with:
-          name: macos-latest-3.13
-          path: /tmp/m313
+          name: macos-latest-3.10
+          path: /tmp/m310
       - uses: actions/download-artifact@v6
         with:
-          name: windows-latest-3.9
-          path: /tmp/w39
+          name: macos-latest-3.14
+          path: /tmp/m314
       - uses: actions/download-artifact@v6
         with:
-          name: windows-latest-3.13
-          path: /tmp/w313
+          name: windows-latest-3.10
+          path: /tmp/w310
+      - uses: actions/download-artifact@v6
+        with:
+          name: windows-latest-3.14
+          path: /tmp/w314
       - name: Install Dependencies
         run: pip install -U coverage coveralls diff-cover
         shell: bash
       - name: Combined Deprecation Messages
         run: |
-          sort -f -u /tmp/u39/alg.dep /tmp/u310/alg.dep /tmp/u311/alg.dep /tmp/u312/alg.dep /tmp/u313/alg.dep /tmp/m39/alg.dep /tmp/m313/alg.dep /tmp/w39/alg.dep /tmp/w313/alg.dep || true
+          sort -f -u /tmp/u310/alg.dep /tmp/u311/alg.dep /tmp/u312/alg.dep /tmp/u313/alg.dep /tmp/u314/alg.dep /tmp/m310/alg.dep /tmp/m314/alg.dep /tmp/w310/alg.dep /tmp/w314/alg.dep || true
         shell: bash
       - name: Coverage combine
-        run: coverage3 combine /tmp/u39/alg.dat
+        run: coverage3 combine /tmp/u310/alg.dat
         shell: bash
       - name: Upload to Coveralls
         env:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,12 +1,12 @@
 queue_rules:
   - name: automerge
     queue_conditions:
-      - check-success=Deprecation_Messages_and_Coverage (3.9)
+      - check-success=Deprecation_Messages_and_Coverage (3.10)
       - "#approved-reviews-by>=1"
       - label=automerge
       - label!=on hold
     merge_conditions:
-      - check-success=Deprecation_Messages_and_Coverage (3.9)
+      - check-success=Deprecation_Messages_and_Coverage (3.10)
     merge_method: squash
 
 pull_request_rules:

--- a/.pylintdict
+++ b/.pylintdict
@@ -103,6 +103,7 @@ filippo
 fletcher
 fm
 fmin
+forkserver
 formatter
 fourier
 frac

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2023, 2025.
+# (C) Copyright IBM 2023, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -64,9 +64,7 @@ rst_prolog = """
     <br><br><br>
 
 .. |version| replace:: {0}
-""".format(
-    release
-)
+""".format(release)
 
 nbsphinx_prolog = """
 {% set docname = env.doc2path(env.docname, base=None) %}

--- a/docs/lowercase_filter.py
+++ b/docs/lowercase_filter.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2023.
+# (C) Copyright IBM 2021, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" Implements a Lower Case Filter for Sphinx spelling """
+"""Implements a Lower Case Filter for Sphinx spelling"""
 
 from enchant import tokenize
 

--- a/docs/tutorials/04_vqd.ipynb
+++ b/docs/tutorials/04_vqd.ipynb
@@ -269,7 +269,6 @@
    "source": [
     "from qiskit_algorithms import NumPyEigensolver\n",
     "\n",
-    "\n",
     "exact_solver = NumPyEigensolver(k=3)\n",
     "exact_result = exact_solver.compute_eigenvalues(H2_op)\n",
     "ref_values = exact_result.eigenvalues"

--- a/docs/tutorials/06_grover.ipynb
+++ b/docs/tutorials/06_grover.ipynb
@@ -122,7 +122,6 @@
     "from qiskit_algorithms import Grover\n",
     "from qiskit.primitives import StatevectorSampler\n",
     "\n",
-    "\n",
     "grover = Grover(sampler=StatevectorSampler())\n",
     "result = grover.amplify(problem)\n",
     "print(\"Result type:\", type(result))\n",

--- a/docs/tutorials/13_trotterQRTE.ipynb
+++ b/docs/tutorials/13_trotterQRTE.ipynb
@@ -699,8 +699,7 @@
     "circuit = circuit.decompose(reps=2)\n",
     "\n",
     "# Let us print some stats\n",
-    "print(\n",
-    "    f\"\"\"\n",
+    "print(f\"\"\"\n",
     "Trotter step with Lie-Trotter\n",
     "-----------------------------\n",
     "\n",
@@ -708,8 +707,7 @@
     "             Gate count: {len(circuit)}\n",
     "    Nonlocal gate count: {circuit.num_nonlocal_gates()}\n",
     "         Gate breakdown: {\", \".join([f\"{k.upper()}: {v}\" for k, v in circuit.count_ops().items()])}\n",
-    "\"\"\"\n",
-    ")\n",
+    "\"\"\")\n",
     "\n",
     "# And finally draw the circuit\n",
     "circuit.draw(\"mpl\")"
@@ -773,8 +771,7 @@
     "circuit = circuit.decompose(reps=2)\n",
     "\n",
     "# Let us print some stats\n",
-    "print(\n",
-    "    f\"\"\"\n",
+    "print(f\"\"\"\n",
     "Trotter step with Suzuki Trotter (2nd order)\n",
     "--------------------------------------------\n",
     "\n",
@@ -783,8 +780,7 @@
     "    Nonlocal gate count: {circuit.num_nonlocal_gates()}\n",
     "         Gate breakdown: {\", \".join([f\"{k.upper()}: {v}\" for k, v in circuit.count_ops().items()])}\n",
     "\n",
-    "\"\"\"\n",
-    ")\n",
+    "\"\"\")\n",
     "\n",
     "# And finally\n",
     "circuit.draw(\"mpl\")"
@@ -823,8 +819,7 @@
     "circuit = circuit.decompose(reps=2)\n",
     "\n",
     "# Let us print some stats\n",
-    "print(\n",
-    "    f\"\"\"\n",
+    "print(f\"\"\"\n",
     "Trotter step with Suzuki Trotter (4th order)\n",
     "--------------------------------------------\n",
     "\n",
@@ -833,8 +828,7 @@
     "    Nonlocal gate count: {circuit.num_nonlocal_gates()}\n",
     "         Gate breakdown: {\", \".join([f\"{k.upper()}: {v}\" for k, v in circuit.count_ops().items()])}\n",
     "\n",
-    "\"\"\"\n",
-    ")"
+    "\"\"\")"
    ]
   },
   {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.black]
 line-length = 100
-target-version = ['py39', 'py310', 'py311', 'py312', 'py313']
+target-version = ['py310', 'py311', 'py312', 'py313', 'py314']
 
 [tool.pylint.main]
 extension-pkg-allow-list = [
@@ -12,7 +12,7 @@ extension-pkg-allow-list = [
     "rustworkx",
 ]
 load-plugins = ["pylint.extensions.docparams", "pylint.extensions.docstyle"]
-py-version = "3.9"  # update it when bumping minimum supported python version
+py-version = "3.10"  # update it when bumping minimum supported python version
 
 [tool.pylint.basic]
 good-names = ["a", "b", "i", "j", "k", "d", "n", "m", "ex", "v", "w", "x", "y", "z", "Run", "_", "logger", "q", "c", "r", "qr", "cr", "qc", "nd", "pi", "op", "b", "ar", "br", "p", "cp", "ax", "dt", "__unittest", "iSwapGate", "mu"]

--- a/qiskit_algorithms/__init__.py
+++ b/qiskit_algorithms/__init__.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2018, 2025.
+# (C) Copyright IBM 2018, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -249,6 +249,7 @@ Utility classes and function used by algorithms.
    utils.algorithm_globals
 
 """
+
 from .algorithm_job import AlgorithmJob
 from .algorithm_result import AlgorithmResult
 from .variational_algorithm import VariationalAlgorithm, VariationalResult

--- a/qiskit_algorithms/algorithm_job.py
+++ b/qiskit_algorithms/algorithm_job.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2025.
+# (C) Copyright IBM 2022, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -13,6 +13,7 @@
 """
 AlgorithmJob class
 """
+
 from qiskit.primitives.primitive_job import PrimitiveJob
 
 

--- a/qiskit_algorithms/amplitude_amplifiers/amplification_problem.py
+++ b/qiskit_algorithms/amplitude_amplifiers/amplification_problem.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2025.
+# (C) Copyright IBM 2021, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -11,6 +11,7 @@
 # that they have been altered from the originals.
 
 """The Amplification problem class."""
+
 from __future__ import annotations
 
 from collections.abc import Callable

--- a/qiskit_algorithms/amplitude_amplifiers/amplitude_amplifier.py
+++ b/qiskit_algorithms/amplitude_amplifiers/amplitude_amplifier.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2023.
+# (C) Copyright IBM 2021, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -11,6 +11,7 @@
 # that they have been altered from the originals.
 
 """The interface for amplification algorithms and results."""
+
 from __future__ import annotations
 
 from abc import ABC, abstractmethod

--- a/qiskit_algorithms/amplitude_amplifiers/grover.py
+++ b/qiskit_algorithms/amplitude_amplifiers/grover.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2018, 2025.
+# (C) Copyright IBM 2018, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -11,6 +11,7 @@
 # that they have been altered from the originals.
 
 """Grover's search algorithm."""
+
 from __future__ import annotations
 
 import itertools

--- a/qiskit_algorithms/custom_types.py
+++ b/qiskit_algorithms/custom_types.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2024, 2025.
+# (C) Copyright IBM 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -11,6 +11,7 @@
 # that they have been altered from the originals.
 
 """Types used by the qiskit-algorithms package."""
+
 from __future__ import annotations
 
 from typing import Any, Protocol, Union

--- a/qiskit_algorithms/minimum_eigensolvers/adapt_vqe.py
+++ b/qiskit_algorithms/minimum_eigensolvers/adapt_vqe.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2025.
+# (C) Copyright IBM 2022, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -11,6 +11,7 @@
 # that they have been altered from the originals.
 
 """An implementation of the AdaptVQE algorithm."""
+
 from __future__ import annotations
 
 import logging

--- a/qiskit_algorithms/minimum_eigensolvers/sampling_vqe.py
+++ b/qiskit_algorithms/minimum_eigensolvers/sampling_vqe.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2025.
+# (C) Copyright IBM 2022, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -41,7 +41,6 @@ from ..utils import validate_initial_point, validate_bounds
 
 # private function as we expect this to be updated in the next released
 from ..utils.set_batching import _set_default_batchsize
-
 
 logger = logging.getLogger(__name__)
 

--- a/qiskit_algorithms/optimizers/adam_amsgrad.py
+++ b/qiskit_algorithms/optimizers/adam_amsgrad.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2019, 2024.
+# (C) Copyright IBM 2019, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -11,6 +11,7 @@
 # that they have been altered from the originals.
 
 """The Adam and AMSGRAD optimizers."""
+
 from __future__ import annotations
 
 from collections.abc import Callable

--- a/qiskit_algorithms/optimizers/gradient_descent.py
+++ b/qiskit_algorithms/optimizers/gradient_descent.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2025.
+# (C) Copyright IBM 2021, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -11,6 +11,7 @@
 # that they have been altered from the originals.
 
 """A standard gradient descent optimizer."""
+
 from __future__ import annotations
 
 from collections.abc import Generator

--- a/qiskit_algorithms/optimizers/imfil.py
+++ b/qiskit_algorithms/optimizers/imfil.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2019, 2023.
+# (C) Copyright IBM 2019, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -11,6 +11,7 @@
 # that they have been altered from the originals.
 
 """IMplicit FILtering (IMFIL) optimizer."""
+
 from __future__ import annotations
 
 from collections.abc import Callable

--- a/qiskit_algorithms/optimizers/nelder_mead.py
+++ b/qiskit_algorithms/optimizers/nelder_mead.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2018, 2024.
+# (C) Copyright IBM 2018, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -11,6 +11,7 @@
 # that they have been altered from the originals.
 
 """Nelder-Mead optimizer."""
+
 from __future__ import annotations
 
 

--- a/qiskit_algorithms/optimizers/nft.py
+++ b/qiskit_algorithms/optimizers/nft.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2019, 2024.
+# (C) Copyright IBM 2019, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -11,6 +11,7 @@
 # that they have been altered from the originals.
 
 """Nakanishi-Fujii-Todo algorithm."""
+
 from __future__ import annotations
 
 

--- a/qiskit_algorithms/optimizers/nlopts/nloptimizer.py
+++ b/qiskit_algorithms/optimizers/nlopts/nloptimizer.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2018, 2025.
+# (C) Copyright IBM 2018, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -11,6 +11,7 @@
 # that they have been altered from the originals.
 
 """Minimize using objective function"""
+
 from __future__ import annotations
 
 from collections.abc import Callable

--- a/qiskit_algorithms/optimizers/optimizer_utils/learning_rate.py
+++ b/qiskit_algorithms/optimizers/optimizer_utils/learning_rate.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2024.
+# (C) Copyright IBM 2021, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -11,6 +11,7 @@
 # that they have been altered from the originals.
 
 """A class to represent the Learning Rate."""
+
 from __future__ import annotations
 
 from collections.abc import Generator, Callable

--- a/qiskit_algorithms/optimizers/p_bfgs.py
+++ b/qiskit_algorithms/optimizers/p_bfgs.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2018, 2024.
+# (C) Copyright IBM 2018, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -11,6 +11,7 @@
 # that they have been altered from the originals.
 
 """Parallelized Limited-memory BFGS optimizer"""
+
 from __future__ import annotations
 
 import logging

--- a/qiskit_algorithms/optimizers/p_bfgs.py
+++ b/qiskit_algorithms/optimizers/p_bfgs.py
@@ -125,7 +125,13 @@ class P_BFGS(SciPyOptimizer):  # pylint: disable=invalid-name
                 "For Windows, using only current process. Multiple core use not supported."
             )
 
-        queue: multiprocessing.queues.Queue[tuple[POINT, float, int]] = multiprocessing.Queue()
+        # From Python 3.14 onward, we have to explicitly set the starting method, which has been
+        # changed to forkserver.
+        # TODO: forkserver might be better to use, but requires some objects to be pickled. A way
+        #  to circumvent this is using dill, but that would introduce a dependency
+        # fork is only available on Linux; on Windows/macOS num_procs is already 0
+        ctx = multiprocessing.get_context("fork") if num_procs > 0 else multiprocessing
+        queue: multiprocessing.queues.Queue[tuple[POINT, float, int]] = ctx.Queue()
 
         # TODO: are automatic bounds a good idea? What if the circuit parameters are not
         # just from plain Pauli rotations but have a coefficient?
@@ -145,7 +151,7 @@ class P_BFGS(SciPyOptimizer):  # pylint: disable=invalid-name
         processes = []
         for _ in range(num_procs):
             i_pt = algorithm_globals.random.uniform(low, high)  # Another random point in bounds
-            proc = multiprocessing.Process(target=optimize_runner, args=(queue, i_pt))
+            proc = ctx.Process(target=optimize_runner, args=(queue, i_pt))
             processes.append(proc)
             proc.start()
 

--- a/qiskit_algorithms/optimizers/powell.py
+++ b/qiskit_algorithms/optimizers/powell.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2018, 2024.
+# (C) Copyright IBM 2018, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -11,6 +11,7 @@
 # that they have been altered from the originals.
 
 """Powell optimizer."""
+
 from __future__ import annotations
 
 from .scipy_optimizer import SciPyOptimizer

--- a/qiskit_algorithms/optimizers/scipy_optimizer.py
+++ b/qiskit_algorithms/optimizers/scipy_optimizer.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2018, 2024.
+# (C) Copyright IBM 2018, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -11,6 +11,7 @@
 # that they have been altered from the originals.
 
 """Wrapper class of scipy.optimize.minimize."""
+
 from __future__ import annotations
 
 from collections.abc import Callable

--- a/qiskit_algorithms/optimizers/slsqp.py
+++ b/qiskit_algorithms/optimizers/slsqp.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2018, 2024.
+# (C) Copyright IBM 2018, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -11,6 +11,7 @@
 # that they have been altered from the originals.
 
 """Sequential Least SQuares Programming optimizer"""
+
 from __future__ import annotations
 
 

--- a/qiskit_algorithms/optimizers/snobfit.py
+++ b/qiskit_algorithms/optimizers/snobfit.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2019, 2023.
+# (C) Copyright IBM 2019, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -11,6 +11,7 @@
 # that they have been altered from the originals.
 
 """Stable Noisy Optimization by Branch and FIT algorithm (SNOBFIT) optimizer."""
+
 from __future__ import annotations
 
 from collections.abc import Callable

--- a/qiskit_algorithms/optimizers/spsa.py
+++ b/qiskit_algorithms/optimizers/spsa.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2018, 2025.
+# (C) Copyright IBM 2018, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -14,6 +14,7 @@
 
 This implementation allows both standard first-order and second-order SPSA.
 """
+
 from __future__ import annotations
 
 from collections import deque

--- a/qiskit_algorithms/optimizers/steppable_optimizer.py
+++ b/qiskit_algorithms/optimizers/steppable_optimizer.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2025.
+# (C) Copyright IBM 2022, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -11,6 +11,7 @@
 # that they have been altered from the originals.
 
 """SteppableOptimizer interface"""
+
 from __future__ import annotations
 
 from abc import abstractmethod, ABC

--- a/qiskit_algorithms/optimizers/tnc.py
+++ b/qiskit_algorithms/optimizers/tnc.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2018, 2024.
+# (C) Copyright IBM 2018, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -11,6 +11,7 @@
 # that they have been altered from the originals.
 
 """Truncated Newton (TNC) optimizer."""
+
 from __future__ import annotations
 
 

--- a/qiskit_algorithms/phase_estimators/phase_estimation_result.py
+++ b/qiskit_algorithms/phase_estimators/phase_estimation_result.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2020, 2025.
+# (C) Copyright IBM 2020, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -11,6 +11,7 @@
 # that they have been altered from the originals.
 
 """Result of running PhaseEstimation"""
+
 from __future__ import annotations
 import numpy
 

--- a/qiskit_algorithms/phase_estimators/phase_estimation_scale.py
+++ b/qiskit_algorithms/phase_estimators/phase_estimation_scale.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2020, 2023.
+# (C) Copyright IBM 2020, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -11,6 +11,7 @@
 # that they have been altered from the originals.
 
 """Scaling for Hamiltonian and eigenvalues to avoid phase wrapping"""
+
 from __future__ import annotations
 import numpy as np
 

--- a/qiskit_algorithms/time_evolvers/classical_methods/evolve.py
+++ b/qiskit_algorithms/time_evolvers/classical_methods/evolve.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2023.
+# (C) Copyright IBM 2022, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -10,6 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 """Auxiliary functions for SciPy Time Evolvers"""
+
 from __future__ import annotations
 import logging
 from scipy.sparse import csr_matrix

--- a/qiskit_algorithms/time_evolvers/classical_methods/scipy_real_evolver.py
+++ b/qiskit_algorithms/time_evolvers/classical_methods/scipy_real_evolver.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2023.
+# (C) Copyright IBM 2022, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -11,6 +11,7 @@
 # that they have been altered from the originals.
 
 """Classical Quantum Real Time Evolution."""
+
 from .evolve import _evolve
 from ..time_evolution_problem import TimeEvolutionProblem
 from ..time_evolution_result import TimeEvolutionResult

--- a/qiskit_algorithms/time_evolvers/pvqd/pvqd.py
+++ b/qiskit_algorithms/time_evolvers/pvqd/pvqd.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2019, 2025.
+# (C) Copyright IBM 2019, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -11,6 +11,7 @@
 # that they have been altered from the originals.
 
 """The projected Variational Quantum Dynamics Algorithm."""
+
 from __future__ import annotations
 
 import logging

--- a/qiskit_algorithms/time_evolvers/pvqd/pvqd_result.py
+++ b/qiskit_algorithms/time_evolvers/pvqd/pvqd_result.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2024.
+# (C) Copyright IBM 2022, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -11,6 +11,7 @@
 # that they have been altered from the originals.
 
 """Result object for p-VQD."""
+
 from __future__ import annotations
 
 from collections.abc import Sequence

--- a/qiskit_algorithms/time_evolvers/pvqd/utils.py
+++ b/qiskit_algorithms/time_evolvers/pvqd/utils.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2025.
+# (C) Copyright IBM 2022, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -12,6 +12,7 @@
 
 
 """Utilities for p-VQD."""
+
 from __future__ import annotations
 import logging
 from collections.abc import Callable

--- a/qiskit_algorithms/time_evolvers/time_evolution_problem.py
+++ b/qiskit_algorithms/time_evolvers/time_evolution_problem.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2024.
+# (C) Copyright IBM 2022, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -11,6 +11,7 @@
 # that they have been altered from the originals.
 
 """Time evolution problem class."""
+
 from __future__ import annotations
 
 from collections.abc import Mapping

--- a/qiskit_algorithms/time_evolvers/time_evolution_result.py
+++ b/qiskit_algorithms/time_evolvers/time_evolution_result.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2023.
+# (C) Copyright IBM 2021, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -11,6 +11,7 @@
 # that they have been altered from the originals.
 
 """Class for holding time evolution result."""
+
 from __future__ import annotations
 import numpy as np
 

--- a/qiskit_algorithms/time_evolvers/trotterization/__init__.py
+++ b/qiskit_algorithms/time_evolvers/trotterization/__init__.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2023.
+# (C) Copyright IBM 2022, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -9,7 +9,7 @@
 # Any modifications or derivative works of this code must retain this
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
-""" The Time Evolvers, Trotterization package"""
+"""The Time Evolvers, Trotterization package"""
 
 from .trotter_qrte import TrotterQRTE
 

--- a/qiskit_algorithms/time_evolvers/variational/__init__.py
+++ b/qiskit_algorithms/time_evolvers/variational/__init__.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2023, 2025.
+# (C) Copyright IBM 2023, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -91,6 +91,7 @@ e.g. RK45.
    ForwardEulerSolver
 
 """
+
 from .solvers.ode.forward_euler_solver import ForwardEulerSolver
 from .var_qrte import VarQRTE
 from .var_qite import VarQITE

--- a/qiskit_algorithms/time_evolvers/variational/solvers/ode/abstract_ode_function.py
+++ b/qiskit_algorithms/time_evolvers/variational/solvers/ode/abstract_ode_function.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2023.
+# (C) Copyright IBM 2023, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -11,6 +11,7 @@
 # that they have been altered from the originals.
 
 """Abstract class for generating ODE functions."""
+
 from __future__ import annotations
 
 from abc import ABC, abstractmethod

--- a/qiskit_algorithms/time_evolvers/variational/solvers/ode/forward_euler_solver.py
+++ b/qiskit_algorithms/time_evolvers/variational/solvers/ode/forward_euler_solver.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2023, 2025.
+# (C) Copyright IBM 2023, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -10,6 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 """Forward Euler ODE solver."""
+
 from collections.abc import Callable, Sequence
 
 import numpy as np

--- a/qiskit_algorithms/time_evolvers/variational/solvers/ode/ode_function.py
+++ b/qiskit_algorithms/time_evolvers/variational/solvers/ode/ode_function.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2023.
+# (C) Copyright IBM 2023, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -11,6 +11,7 @@
 # that they have been altered from the originals.
 
 """Class for generating ODE functions based on ODE gradients."""
+
 from collections.abc import Iterable
 
 from .abstract_ode_function import AbstractOdeFunction

--- a/qiskit_algorithms/time_evolvers/variational/solvers/ode/ode_function_factory.py
+++ b/qiskit_algorithms/time_evolvers/variational/solvers/ode/ode_function_factory.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2023.
+# (C) Copyright IBM 2023, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -11,6 +11,7 @@
 # that they have been altered from the originals.
 
 """Abstract class for generating ODE functions."""
+
 from __future__ import annotations
 
 from abc import ABC

--- a/qiskit_algorithms/time_evolvers/variational/solvers/ode/var_qte_ode_solver.py
+++ b/qiskit_algorithms/time_evolvers/variational/solvers/ode/var_qte_ode_solver.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2023.
+# (C) Copyright IBM 2023, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -11,6 +11,7 @@
 # that they have been altered from the originals.
 
 """Class for solving ODEs for Quantum Time Evolution."""
+
 from __future__ import annotations
 
 from collections.abc import Sequence

--- a/qiskit_algorithms/time_evolvers/variational/solvers/var_qte_linear_solver.py
+++ b/qiskit_algorithms/time_evolvers/variational/solvers/var_qte_linear_solver.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2023, 2024.
+# (C) Copyright IBM 2023, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -11,6 +11,7 @@
 # that they have been altered from the originals.
 
 """Class for solving linear equations for Quantum Time Evolution."""
+
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence, Callable

--- a/qiskit_algorithms/time_evolvers/variational/var_qite.py
+++ b/qiskit_algorithms/time_evolvers/variational/var_qite.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2023, 2025.
+# (C) Copyright IBM 2023, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -11,6 +11,7 @@
 # that they have been altered from the originals.
 
 """Variational Quantum Imaginary Time Evolution algorithm."""
+
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence

--- a/qiskit_algorithms/time_evolvers/variational/var_qrte.py
+++ b/qiskit_algorithms/time_evolvers/variational/var_qrte.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2023, 2025.
+# (C) Copyright IBM 2023, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -11,6 +11,7 @@
 # that they have been altered from the originals.
 
 """Variational Quantum Real Time Evolution algorithm."""
+
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence

--- a/qiskit_algorithms/time_evolvers/variational/var_qte.py
+++ b/qiskit_algorithms/time_evolvers/variational/var_qte.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2023, 2025.
+# (C) Copyright IBM 2023, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -11,6 +11,7 @@
 # that they have been altered from the originals.
 
 """The Variational Quantum Time Evolution Interface"""
+
 from __future__ import annotations
 
 from abc import ABC

--- a/qiskit_algorithms/time_evolvers/variational/var_qte_result.py
+++ b/qiskit_algorithms/time_evolvers/variational/var_qte_result.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2023, 2024.
+# (C) Copyright IBM 2023, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -11,6 +11,7 @@
 # that they have been altered from the originals.
 
 """Result object for varQTE."""
+
 from __future__ import annotations
 
 import numpy as np

--- a/qiskit_algorithms/time_evolvers/variational/variational_principles/imaginary_mc_lachlan_principle.py
+++ b/qiskit_algorithms/time_evolvers/variational/variational_principles/imaginary_mc_lachlan_principle.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2023, 2025.
+# (C) Copyright IBM 2023, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -11,6 +11,7 @@
 # that they have been altered from the originals.
 
 """Class for an Imaginary McLachlan's Variational Principle."""
+
 from __future__ import annotations
 
 import warnings

--- a/qiskit_algorithms/time_evolvers/variational/variational_principles/real_mc_lachlan_principle.py
+++ b/qiskit_algorithms/time_evolvers/variational/variational_principles/real_mc_lachlan_principle.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2023, 2025.
+# (C) Copyright IBM 2023, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -11,6 +11,7 @@
 # that they have been altered from the originals.
 
 """Class for a Real McLachlan's Variational Principle."""
+
 from __future__ import annotations
 
 import warnings

--- a/qiskit_algorithms/time_evolvers/variational/variational_principles/variational_principle.py
+++ b/qiskit_algorithms/time_evolvers/variational/variational_principles/variational_principle.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2023.
+# (C) Copyright IBM 2023, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -11,6 +11,7 @@
 # that they have been altered from the originals.
 
 """Class for a Variational Principle."""
+
 from __future__ import annotations
 
 from abc import ABC, abstractmethod

--- a/qiskit_algorithms/utils/circuit_key.py
+++ b/qiskit_algorithms/utils/circuit_key.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2025.
+# (C) Copyright IBM 2025, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -15,6 +15,7 @@ _circuit_key function from Qiskit 1.4
 This file is to be deleted once all interfaces such as the BaseStateFidelity's and gradients' accept
 PUB-like inputs instead of separate arguments.
 """
+
 from typing import Iterable
 
 import numpy as np

--- a/releasenotes/notes/remove-python-39-support-and-added-python-314-support-fba957ddc1e3da31.yaml
+++ b/releasenotes/notes/remove-python-39-support-and-added-python-314-support-fba957ddc1e3da31.yaml
@@ -1,0 +1,10 @@
+---
+features:
+  - |
+    Added Python 3.14 support.
+upgrade:
+  - |
+    Python 3.9 support was dropped as Python 3.8 reached End Of Life
+    in October 2025 and is no longer being maintained. If you were
+    using Python 3.9 you should upgrade to a newer version that Qiskit
+    Algorithms now supports.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 coverage>=4.4.0,<7.0
 matplotlib>=3.3
 jupyter
-black[jupyter]~=24.1
+black[jupyter]~=26.0
 pylint>=2.15.0
 stestr>=2.0.0
 pylatexenc>=1.4

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2025.
+# (C) Copyright IBM 2021, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -61,18 +61,18 @@ setuptools.setup(
         "Operating System :: MacOS",
         "Operating System :: POSIX :: Linux",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
         "Topic :: Scientific/Engineering",
     ],
     keywords="qiskit sdk quantum algorithms",
     packages=setuptools.find_packages(include=["qiskit_algorithms", "qiskit_algorithms.*"]),
     install_requires=REQUIREMENTS,
     include_package_data=True,
-    python_requires=">=3.9",
+    python_requires=">=3.10",
     project_urls={
         "Bug Tracker": "https://github.com/qiskit-community/qiskit-algorithms/issues",
         "Documentation": "https://qiskit-community.github.io/qiskit-algorithms/",

--- a/test/eigensolvers/test_vqd.py
+++ b/test/eigensolvers/test_vqd.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2025.
+# (C) Copyright IBM 2022, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -28,7 +28,6 @@ from qiskit_algorithms.eigensolvers import VQD, VQDResult
 from qiskit_algorithms.optimizers import COBYLA, L_BFGS_B, SLSQP, SPSA
 from qiskit_algorithms.state_fidelities import ComputeUncompute
 from qiskit_algorithms.utils import algorithm_globals
-
 
 H2_SPARSE_PAULI = SparsePauliOp.from_list(
     [

--- a/test/gradients/logging_primitives.py
+++ b/test/gradients/logging_primitives.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2025.
+# (C) Copyright IBM 2022, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -11,6 +11,7 @@
 # that they have been altered from the originals.
 
 """Test primitives that check what kind of operations are in the circuits they execute."""
+
 from __future__ import annotations
 from typing import Iterable
 

--- a/test/minimum_eigensolvers/test_adapt_vqe.py
+++ b/test/minimum_eigensolvers/test_adapt_vqe.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2025.
+# (C) Copyright IBM 2022, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -30,7 +30,6 @@ from qiskit_algorithms.minimum_eigensolvers import VQE
 from qiskit_algorithms.minimum_eigensolvers.adapt_vqe import AdaptVQE, TerminationCriterion
 from qiskit_algorithms.optimizers import SLSQP
 from qiskit_algorithms.utils import algorithm_globals
-
 
 FIVE_QUBITS_BACKEND = GenericBackendV2(
     num_qubits=5, coupling_map=[[0, 1], [1, 2], [2, 3], [3, 4]], seed=54

--- a/test/minimum_eigensolvers/test_qaoa.py
+++ b/test/minimum_eigensolvers/test_qaoa.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2025.
+# (C) Copyright IBM 2022, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -29,7 +29,6 @@ from scipy.optimize import minimize as scipy_minimize
 from qiskit_algorithms.minimum_eigensolvers import QAOA
 from qiskit_algorithms.optimizers import COBYLA, NELDER_MEAD
 from qiskit_algorithms.utils import algorithm_globals
-
 
 W1 = np.array([[0, 1, 0, 1], [1, 0, 1, 0], [0, 1, 0, 1], [1, 0, 1, 0]])
 P1 = 1

--- a/test/minimum_eigensolvers/test_sampling_vqe.py
+++ b/test/minimum_eigensolvers/test_sampling_vqe.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2018, 2025.
+# (C) Copyright IBM 2018, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -11,7 +11,6 @@
 # that they have been altered from the originals.
 
 """Test the Sampler VQE."""
-
 
 import unittest
 from functools import partial

--- a/test/minimum_eigensolvers/test_vqe.py
+++ b/test/minimum_eigensolvers/test_vqe.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2025.
+# (C) Copyright IBM 2022, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -46,7 +46,6 @@ from qiskit_algorithms.optimizers import (
 )
 from qiskit_algorithms.state_fidelities import ComputeUncompute
 from qiskit_algorithms.utils import algorithm_globals
-
 
 THREE_QUBITS_BACKEND = GenericBackendV2(num_qubits=3, coupling_map=[[0, 1], [1, 2]], seed=54)
 

--- a/test/test_phase_estimator.py
+++ b/test/test_phase_estimator.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2018, 2025.
+# (C) Copyright IBM 2018, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -11,6 +11,7 @@
 # that they have been altered from the originals.
 
 """Test phase estimation"""
+
 import unittest
 from test import QiskitAlgorithmsTestCase
 

--- a/test/time_evolvers/classical_methods/test_scipy_imaginary_evolver.py
+++ b/test/time_evolvers/classical_methods/test_scipy_imaginary_evolver.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2023.
+# (C) Copyright IBM 2022, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -11,6 +11,7 @@
 # that they have been altered from the originals.
 
 """Test Classical Imaginary Evolver."""
+
 import unittest
 from test import QiskitAlgorithmsTestCase
 from typing import cast

--- a/test/time_evolvers/classical_methods/test_scipy_real_evolver.py
+++ b/test/time_evolvers/classical_methods/test_scipy_real_evolver.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2023.
+# (C) Copyright IBM 2022, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -11,6 +11,7 @@
 # that they have been altered from the originals.
 
 """Test Classical Real Evolver."""
+
 import unittest
 from test import QiskitAlgorithmsTestCase
 from ddt import data, ddt, unpack

--- a/test/time_evolvers/test_pvqd.py
+++ b/test/time_evolvers/test_pvqd.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2018, 2025.
+# (C) Copyright IBM 2018, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -11,6 +11,7 @@
 # that they have been altered from the originals.
 
 """Tests for PVQD."""
+
 import unittest
 from test import QiskitAlgorithmsTestCase
 from functools import partial

--- a/test/time_evolvers/test_time_evolution_problem.py
+++ b/test/time_evolvers/test_time_evolution_problem.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2023.
+# (C) Copyright IBM 2022, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -11,6 +11,7 @@
 # that they have been altered from the originals.
 
 """Test evolver problem class."""
+
 import unittest
 from test import QiskitAlgorithmsTestCase
 from ddt import data, ddt

--- a/test/time_evolvers/test_time_evolution_result.py
+++ b/test/time_evolvers/test_time_evolution_result.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2023.
+# (C) Copyright IBM 2022, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -10,6 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 """Class for testing evolution result."""
+
 import unittest
 from test import QiskitAlgorithmsTestCase
 from qiskit import QuantumCircuit

--- a/test/time_evolvers/variational/solvers/expected_results/test_varqte_linear_solver_expected_1.py
+++ b/test/time_evolvers/variational/solvers/expected_results/test_varqte_linear_solver_expected_1.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2023.
+# (C) Copyright IBM 2023, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -10,6 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 """Stores expected results that are lengthy."""
+
 expected_metric_res_1 = [
     [
         2.50000000e-01 + 0.0j,

--- a/test/time_evolvers/variational/variational_principles/expected_results/test_imaginary_mc_lachlan_variational_principle_expected1.py
+++ b/test/time_evolvers/variational/variational_principles/expected_results/test_imaginary_mc_lachlan_variational_principle_expected1.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2023.
+# (C) Copyright IBM 2023, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -10,6 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 """Stores expected results that are lengthy."""
+
 expected_bound_metric_tensor_1 = [
     [
         2.50000000e-01 + 0.0j,

--- a/test/time_evolvers/variational/variational_principles/expected_results/test_imaginary_mc_lachlan_variational_principle_expected2.py
+++ b/test/time_evolvers/variational/variational_principles/expected_results/test_imaginary_mc_lachlan_variational_principle_expected2.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2023.
+# (C) Copyright IBM 2023, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -10,6 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 """Stores expected results that are lengthy."""
+
 expected_bound_metric_tensor_2 = [
     [
         2.50000000e-01 + 0.0j,

--- a/test/time_evolvers/variational/variational_principles/expected_results/test_imaginary_mc_lachlan_variational_principle_expected3.py
+++ b/test/time_evolvers/variational/variational_principles/expected_results/test_imaginary_mc_lachlan_variational_principle_expected3.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2023.
+# (C) Copyright IBM 2023, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -10,6 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 """Stores expected results that are lengthy."""
+
 expected_bound_metric_tensor_3 = [
     [
         -1.21000000e-34 + 0.00e00j,

--- a/tools/check_copyright.py
+++ b/tools/check_copyright.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2020, 2023.
+# (C) Copyright IBM 2020, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" Fix copyright year in header """
+"""Fix copyright year in header"""
 
 from typing import Tuple, Union, List
 import builtins

--- a/tools/extract_deprecation.py
+++ b/tools/extract_deprecation.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2023.
+# (C) Copyright IBM 2021, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" Extract deprecation messages from input """
+"""Extract deprecation messages from input"""
 
 from typing import List
 import sys

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 # Sets this min.version because of differences with env_tmp_dir env.
 minversion = 4.0.2
-envlist = py39, py310, py311, py312, py313, lint
+envlist = py310, py311, py312, py313, py314, lint
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
### Summary
The nightly build currently fails because of a job running on Python 3.9. Python 3.9 has reached its EOL in October 2025 and shouldn't be supported anymore. This PR removes the support of Python 3.9 and adds the support for Python 3.14. This fixes one of the two failures currently seen in the nightly build, the other one being the Qiskit monitoring, which is due to a recent bug introduced in Qiskit (see https://github.com/Qiskit/qiskit/issues/15834).

### Details and comments
- In a30326a75e2fc62294a82a1a313ec34f6a80e183:
    - Black had to be updated in order to support Python 3.14.
    - The Python version used to perform the Checks job had to be updated to 3.14, since Black was otherwise complaining that it couldn't check 3.14 code while running using 3.10.
- In 4d225d6e66c42e16d4bbf8bd0a5e7553c23259cd:
    - The start method of `multiprocessing` has been explicitly set to `fork` in P_BFGS, which was the default before Python 3.14. Using the potentially desirable default `forkserver` would require pickling items, potentially requiring `dill`, which would add a dependency. The change in`multiprocessing` in Python 3.14 is documented [here](https://docs.python.org/3/whatsnew/3.14.html#multiprocessing).
- In 484a0224880c977072c7568deb9053307d6efe52:
    - All of the files that have been modified in this commit have been so that they pass the new Black formatting.