### PR TITLE
Ensure the full parameter array is passed to the VQE callback.

### DIFF
--- a/qiskit_algorithms/minimum_eigensolvers/vqe.py
+++ b/qiskit_algorithms/minimum_eigensolvers/vqe.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2025.
+# (C) Copyright IBM 2022, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_algorithms/minimum_eigensolvers/vqe.py
+++ b/qiskit_algorithms/minimum_eigensolvers/vqe.py
@@ -333,7 +333,7 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
                 values = values.reshape(1)
 
             if self.callback is not None:
-                for params, value in zip(parameters.reshape(-1, 1), values):
+                for params, value in zip(parameters, values):
                     eval_count += 1
                     self.callback(eval_count, params, value, estimator_result.metadata)
 

--- a/test/minimum_eigensolvers/test_vqe.py
+++ b/test/minimum_eigensolvers/test_vqe.py
@@ -243,6 +243,7 @@ class TestVQE(QiskitAlgorithmsTestCase):
         self.assertTrue(all(isinstance(metadata, dict) for metadata in history["metadata"]))
         for params in history["parameters"]:
             self.assertTrue(all(isinstance(param, float) for param in params))
+            self.assertTrue(len(params) == wavefunction.num_parameters)
 
     def test_reuse(self):
         """Test re-using a VQE algorithm instance."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
As a result of commit 28f486fb, the change in [this line](https://github.com/qiskit-community/qiskit-algorithms/blob/28f486fb5be1d77e90c0926a96af075099417cfb/qiskit_algorithms/minimum_eigensolvers/vqe.py#L335) means that only the first element of the optimized-parameter array is passed to the VQE callback. The proposed correction makes the full array available again.