### PR TITLE
Backport fixes for issue #275 to stable/0.4

### DIFF
--- a/.pylintdict
+++ b/.pylintdict
@@ -103,6 +103,7 @@ filippo
 fletcher
 fm
 fmin
+forkserver
 formatter
 fourier
 frac

--- a/qiskit_algorithms/optimizers/p_bfgs.py
+++ b/qiskit_algorithms/optimizers/p_bfgs.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2018, 2024.
+# (C) Copyright IBM 2018, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -125,7 +125,12 @@ class P_BFGS(SciPyOptimizer):  # pylint: disable=invalid-name
                 "For Windows, using only current process. Multiple core use not supported."
             )
 
-        queue: multiprocessing.queues.Queue[tuple[POINT, float, int]] = multiprocessing.Queue()
+        # Python 3.14 changed the default POSIX start method from fork to forkserver. P_BFGS
+        # relies on fork because the optimization callables are commonly local closures and
+        # therefore cannot be pickled for forkserver.
+        # fork is available on POSIX; Windows/macOS have already disabled workers above.
+        ctx = multiprocessing.get_context("fork") if num_procs > 0 else multiprocessing
+        queue: multiprocessing.queues.Queue[tuple[POINT, float, int]] = ctx.Queue()
 
         # TODO: are automatic bounds a good idea? What if the circuit parameters are not
         # just from plain Pauli rotations but have a coefficient?
@@ -145,7 +150,7 @@ class P_BFGS(SciPyOptimizer):  # pylint: disable=invalid-name
         processes = []
         for _ in range(num_procs):
             i_pt = algorithm_globals.random.uniform(low, high)  # Another random point in bounds
-            proc = multiprocessing.Process(target=optimize_runner, args=(queue, i_pt))
+            proc = ctx.Process(target=optimize_runner, args=(queue, i_pt))
             processes.append(proc)
             proc.start()
 

--- a/qiskit_algorithms/time_evolvers/trotterization/trotter_qrte.py
+++ b/qiskit_algorithms/time_evolvers/trotterization/trotter_qrte.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2025.
+# (C) Copyright IBM 2021, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -251,6 +251,7 @@ class TrotterQRTE(RealTimeEvolver):
                     synthesis=self.product_formula,
                 )
             evolved_state.append(single_step_evolution_gate, evolved_state.qubits)
+            evolved_state = evolved_state.decompose()
 
             if self._transpiler is not None:
                 evolved_state = self._transpiler.run(evolved_state, **self._transpiler_options)

--- a/releasenotes/notes/0.4/fix_issue_275-0c42d723395da9cc.yaml
+++ b/releasenotes/notes/0.4/fix_issue_275-0c42d723395da9cc.yaml
@@ -1,0 +1,11 @@
+---
+fixes:
+  - |
+    Fixed :class:`.P_BFGS` on Linux with Python 3.14 by explicitly using the
+    ``fork`` multiprocessing context. Python 3.14 changed the default POSIX
+    start method to ``forkserver``, which cannot serialize the local
+    optimization callables used by :class:`.P_BFGS`.
+  - |
+    Fixed :class:`.TrotterQRTE` results with recent Qiskit versions by
+    decomposing each :class:`~qiskit.circuit.library.PauliEvolutionGate`
+    before evaluating or returning the evolved circuit.

--- a/test/optimizers/test_optimizers.py
+++ b/test/optimizers/test_optimizers.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2018, 2025.
+# (C) Copyright IBM 2018, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -13,6 +13,7 @@
 """Test Optimizers"""
 
 import unittest
+from unittest.mock import patch
 
 from test import QiskitAlgorithmsTestCase
 
@@ -116,6 +117,26 @@ class TestOptimizers(QiskitAlgorithmsTestCase):
         """parallel l_bfgs_b test"""
         optimizer = P_BFGS(maxfun=1000, max_processes=4)
         self.run_optimizer(optimizer, max_nfev=10000)
+
+    def test_p_bfgs_uses_fork_context(self):
+        """P_BFGS explicitly selects fork on platforms that support parallelism."""
+
+        class ForkContextRequested(Exception):
+            """Raised when the mocked fork context is requested."""
+
+        optimizer = P_BFGS(maxfun=1000, max_processes=2)
+        with patch("qiskit_algorithms.optimizers.p_bfgs.platform.system", return_value="Linux"):
+            with patch(
+                "qiskit_algorithms.optimizers.p_bfgs.multiprocessing.cpu_count", return_value=2
+            ):
+                with patch(
+                    "qiskit_algorithms.optimizers.p_bfgs.multiprocessing.get_context",
+                    side_effect=ForkContextRequested,
+                ) as get_context:
+                    with self.assertRaises(ForkContextRequested):
+                        optimizer.minimize(rosen, np.asarray([1.13, 0.7, 0.8, 1.9, 1.2]))
+
+        get_context.assert_called_once_with("fork")
 
     def test_nelder_mead(self):
         """nelder mead test"""

--- a/test/time_evolvers/test_trotter_qrte.py
+++ b/test/time_evolvers/test_trotter_qrte.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2025.
+# (C) Copyright IBM 2021, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -136,6 +136,12 @@ class TestTrotterQRTE(QiskitAlgorithmsTestCase):
         (
             SparsePauliOp([Pauli("XY"), Pauli("YX")]),
             Statevector([-0.41614684 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j, 0.90929743 + 0.0j]),
+        ),
+        (
+            SparsePauliOp([Pauli("XY"), Pauli("XX")]),  # Non-commuting case
+            Statevector(
+                [0.291926582 - 0.708073418j, 0.0 + 0.0j, 0.0 + 0.0j, 0.454648713 - 0.454648713j]
+            ),
         ),
         (
             SparsePauliOp([Pauli("ZZ"), Pauli("ZI"), Pauli("IZ")]),


### PR DESCRIPTION
### Summary

Backports the two fixes needed for #275 to `stable/0.4`:

- #268 / `4d225d6`: explicitly use the `fork` multiprocessing context in `P_BFGS`, avoiding Python 3.14's new `forkserver` default trying to pickle local optimization callables.
- #252 / `6700f3c`: decompose each `PauliEvolutionGate` before evaluating or returning `TrotterQRTE` circuits, preserving synthesized product-formula results with recent Qiskit releases.
- Add regression coverage and a 0.4 release note.

Fixes #275

### Validation

- Exact issue and regression tests: 9 passed.
- Optimizer, VQE, and TrotterQRTE suites: 93 passed, 10 skipped.
- Black, Pylint (10.00/10), copyright, headers, Reno, dependency, and whitespace checks passed.
- Serial and four-worker repository-wide runs reported no failures before reaching the 15-minute local execution limit on slow numerical tests.