### PR TITLE
Read amplitude estimator shots from BitArray

### DIFF
--- a/qiskit_algorithms/amplitude_estimators/ae.py
+++ b/qiskit_algorithms/amplitude_estimators/ae.py
@@ -334,7 +334,7 @@ class AmplitudeEstimation(AmplitudeEstimator):
             raise AlgorithmError("The job was not completed successfully. ") from exc
 
         circuit_results = getattr(ret.data, next(iter(ret.data.keys())))
-        shots = ret.metadata["shots"]
+        shots = circuit_results.num_shots
 
         result.circuit_results = circuit_results.get_counts()
 

--- a/qiskit_algorithms/amplitude_estimators/fae.py
+++ b/qiskit_algorithms/amplitude_estimators/fae.py
@@ -115,7 +115,7 @@ class FasterAmplitudeEstimation(AmplitudeEstimator):
             raise AlgorithmError("The job was not completed successfully. ") from exc
 
         circuit_results = getattr(result.data, next(iter(result.data.keys())))
-        shots = result.metadata["shots"]
+        shots = circuit_results.num_shots
 
         self._num_oracle_calls += (2 * k + 1) * shots
 

--- a/qiskit_algorithms/amplitude_estimators/iae.py
+++ b/qiskit_algorithms/amplitude_estimators/iae.py
@@ -329,7 +329,7 @@ class IterativeAmplitudeEstimation(AmplitudeEstimator):
                 raise AlgorithmError("The job was not completed successfully. ") from exc
 
             circuit_results = getattr(ret.data, next(iter(ret.data.keys())))
-            shots = ret.metadata["shots"]
+            shots = circuit_results.num_shots
 
             counts = circuit_results.get_counts()
 

--- a/releasenotes/notes/sampler-v2-bitarray-shots-42b9f9454a324991.yaml
+++ b/releasenotes/notes/sampler-v2-bitarray-shots-42b9f9454a324991.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixed :class:`.AmplitudeEstimation`, :class:`.IterativeAmplitudeEstimation`,
+    and :class:`.FasterAmplitudeEstimation` for SamplerV2 implementations that omit
+    the number of shots from result metadata. The algorithms now obtain the shot
+    count from the returned :class:`~qiskit.primitives.BitArray`.

--- a/test/test_amplitude_estimators.py
+++ b/test/test_amplitude_estimators.py
@@ -81,6 +81,15 @@ class SineIntegral(QuantumCircuit):
             self.cry(2 * 2**i / 2**num_qubits, qubit, qr_objective[0])
 
 
+class MetadataFreeStatevectorSampler(StatevectorSampler):
+    """A statevector sampler that omits shot metadata from its results."""
+
+    def _run_pub(self, pub):
+        result = super()._run_pub(pub)
+        result.metadata.pop("shots", None)
+        return result
+
+
 @ddt
 class TestBernoulli(QiskitAlgorithmsTestCase):
     """Tests based on the Bernoulli A operator.
@@ -122,6 +131,24 @@ class TestBernoulli(QiskitAlgorithmsTestCase):
             self.assertAlmostEqual(
                 value, getattr(result, key), places=3, msg=f"estimate `{key}` failed"
             )
+
+    def test_sampler_without_shot_metadata(self):
+        """Sampler results need not include the number of shots in their metadata."""
+        problem = EstimationProblem(BernoulliStateIn(0.2), [0], BernoulliGrover(0.2))
+        algorithms = [
+            AmplitudeEstimation(2),
+            IterativeAmplitudeEstimation(0.1, 0.1),
+            FasterAmplitudeEstimation(0.1, 1, rescale=False),
+        ]
+
+        for algorithm in algorithms:
+            with self.subTest(algorithm=type(algorithm).__name__):
+                algorithm.sampler = MetadataFreeStatevectorSampler(default_shots=1_000, seed=42)
+                result = algorithm.estimate(problem)
+                self.assertIsNotNone(result.estimation)
+                if isinstance(algorithm, AmplitudeEstimation):
+                    self.assertEqual(result.shots, 1_000)
+                    self.assertEqual(sum(result.circuit_results.values()), 1_000)
 
     @data(True, False)
     def test_qae_circuit(self, efficient_circuit):


### PR DESCRIPTION
Fixes #273

### Summary

- obtain the actual shot count from each returned measurement `BitArray` instead of implementation-specific SamplerV2 result metadata
- apply the fix consistently to `AmplitudeEstimation`, `IterativeAmplitudeEstimation`, and `FasterAmplitudeEstimation`
- add regression coverage using valid sampler results without a `shots` metadata entry, plus a release note

SamplerV2 pub-result metadata is implementation-defined, and Runtime sampler results may omit `shots`. The measurement `BitArray.num_shots` is the contract-backed source of the returned sample count.

### Tests

- `python -m unittest -v test.test_amplitude_estimators` (31 tests run, 1 skipped)
- `python -m black --check qiskit_algorithms test tools docs`
- `python -m pylint -rn qiskit_algorithms test tools` (10.00/10)
- `python tools/verify_headers.py qiskit_algorithms test tools`
- `python tools/check_copyright.py -check -path <repo>`
- `python tools/find_stray_release_notes.py`
- `reno lint`

The same defect is present on `stable/0.4`, so this is also a backport candidate.